### PR TITLE
fix: invoice and receipt search

### DIFF
--- a/src/app/pages/accounts/chart-accounts/chart-of-accounts/chart-of-accounts.component.ts
+++ b/src/app/pages/accounts/chart-accounts/chart-of-accounts/chart-of-accounts.component.ts
@@ -10,7 +10,7 @@ declare var $: any;
 })
 export class ChartOfAccountsComponent implements OnInit {
   modalTitle = 'Add Account';
-  dataMessage: string = Constants.FETCHING_DATA;
+  dataMessage = Constants.NO_RECORDS_FOUND;
   accounts: any = [];
   parentMessage: '';
   filter = {

--- a/src/app/pages/accounts/invoices/add-invoice/add-invoice.component.ts
+++ b/src/app/pages/accounts/invoices/add-invoice/add-invoice.component.ts
@@ -27,7 +27,7 @@ export class AddInvoiceComponent implements OnInit {
     users: any = [];
   invoiceData = {
     invNo: '',
-    txnDate: null,
+    txnDate: moment().format('YYYY-MM-DD'),
     invRef: '',
     invCur: null,
     invDueDate: null,
@@ -261,6 +261,7 @@ export class AddInvoiceComponent implements OnInit {
     this.errors = {};
     this.hasError = false;
     this.hasSuccess = false;
+    console.log('this.invoiceData', this.invoiceData);
     this.accountService.postData(`invoices`, this.invoiceData).subscribe({
       complete: () => { },
       error: (err: any) => {
@@ -360,7 +361,8 @@ export class AddInvoiceComponent implements OnInit {
     this.errors = {};
     this.hasError = false;
     this.hasSuccess = false;
-    // this.invoiceData.balance = this.invoiceData.finalAmount;
+    this.invoiceData.balance = this.invoiceData.finalAmount;
+    console.log('this.invoiceData', this.invoiceData);
     this.accountService.putData(`invoices/update/${this.invID}`, this.invoiceData).subscribe({
       complete: () => { },
       error: (err: any) => {

--- a/src/app/pages/accounts/invoices/invoice-list/invoice-list.component.html
+++ b/src/app/pages/accounts/invoices/invoice-list/invoice-list.component.html
@@ -31,7 +31,7 @@
            </div>
             <div class="col-md-2  col-lg-2">
               <button type="button" class="btn btn-sm btn-success" (click)="searchFilter()">Search</button>
-              <!-- <button type="button" class="btn btn-sm btn-success ml-1" (click)="resetFilter()">Reset</button> -->
+              <button type="button" class="btn btn-sm btn-success ml-1" (click)="resetFilter()">Reset</button>
             </div>
             <div class="col-md-5  col-lg-5 text-right pr-5">
               <a routerLink="/accounts/invoices/add" class="btn btn-success btn-sm ml-2" style="color:white;"><i
@@ -175,8 +175,7 @@
                         {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                         {{customersObjects[inv.customerID]}}</td>
-                      <td class="loadid cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='orderInvoice'">{{inv.invNo}}</span></td>
+                      <td class="loadid cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.charges.freightFee.amount}}{{inv.charges.freightFee.currency}}
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -184,16 +183,10 @@
                           {{inv.charges.accessorialDeductionInfo.total}}{{inv.charges.freightFee.currency}}</span><br>
                         <span *ngIf="inv.invType==='orderInvoice'">Deduct:
                           {{inv.charges.accessorialFeeInfo.total}}{{inv.charges.freightFee.currency}}</span></td>
-                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='manual'">{{inv.taxAmount}}{{inv.invCur}}</span>
-                        <span
-                          *ngIf="inv.invType==='orderInvoice'">{{inv.taxesAmt}}{{inv.charges.freightFee.currency}}</span>
+                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.taxesAmt}}{{inv.charges.freightFee.currency}}
                       </td>
-                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='manual'">{{inv.finalAmount}} {{inv.invCur}}</span>
-                        <span *ngIf="inv.invType==='orderInvoice'">
+                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.finalAmount}} {{inv.charges.freightFee.currency}}
-                        </span>
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
 
@@ -201,12 +194,7 @@
 
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
-                        <span *ngIf="inv.invType==='manual'">
-                          {{inv.balance}} {{inv.invCur}}
-                        </span>
-                        <span *ngIf="inv.invType==='orderInvoice'">
                           {{inv.balance}} {{inv.charges.freightFee.currency}}
-                        </span>
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                         -
@@ -222,10 +210,7 @@
                               class="fas fa-ellipsis-v"></i></button>
                           <div class="dropdown-menu" role="menu">
                             <!-- <button type="button" (click)="changeStatus(inv.invID)" class="dropdown-item text-1">Change
-                              Status</button>
-                            <a class="dropdown-item text-1"
-                              *ngIf="inv.invStatus !== 'paid' && inv.invStatus !== 'voided'"
-                              routerLink="/accounts/invoices/edit/{{inv.invID}}">Edit</a> -->
+                              Status</button> -->
                             <button type="button" *ngIf="inv.invStatus !== 'paid' && inv.invStatus !== 'voided' && inv.invStatus !== 'partially paid'"
                               class="dropdown-item text-1" (click)="deleteOrderInvoice(inv.invID, inv.orderID)">Delete</button>
                           </div>
@@ -238,47 +223,23 @@
                         {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                         {{customersObjects[inv.customerID]}}</td>
-                      <td class="loadid cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='orderInvoice'">{{inv.invNo}}</span></td>
-                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='orderInvoice'">{{inv.charges.freightFee.amount}}{{inv.charges.freightFee.currency}}</span>
+                      <td class="loadid cursorpoint" (click)="routeFn(inv.invID, inv.invType)">-</td>
+                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">-
+                      </td>
+                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">-</td>
+                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.taxAmount}}{{inv.invCur}}
+                      </td>
+                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.finalAmount}} {{inv.invCur}}
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
-                        <span *ngIf="inv.invType==='orderInvoice'">Add:
-                          {{inv.charges.accessorialDeductionInfo.total}}{{inv.charges.freightFee.currency}}</span><br>
-                        <span *ngIf="inv.invType==='orderInvoice'">Deduct:
-                          {{inv.charges.accessorialFeeInfo.total}}{{inv.charges.freightFee.currency}}</span></td>
-                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='manual'">{{inv.taxAmount}}{{inv.invCur}}</span>
-                        <span
-                          *ngIf="inv.invType==='orderInvoice'">{{inv.taxesAmt}}{{inv.charges.freightFee.currency}}</span>
-                      </td>
-                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)"><span
-                          *ngIf="inv.invType==='manual'">{{inv.finalAmount}} {{inv.invCur}}</span>
-                        <span *ngIf="inv.invType==='orderInvoice'">
-                          {{inv.finalAmount}} {{inv.charges.freightFee.currency}}
-                        </span>
-                      </td>
-                      <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
-                        <span *ngIf="inv.invType==='manual'">
                           {{inv.amountReceived}} {{inv.invCur}}
-                        </span>
-                        <span *ngIf="inv.invType==='orderInvoice'">
-                          {{inv.amountReceived}} {{inv.charges.freightFee.currency}}
-                        </span>
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
-                        <span *ngIf="inv.invType==='manual'">
                           {{inv.balance}} {{inv.invCur}}
-                        </span>
-                        <span *ngIf="inv.invType==='orderInvoice'">
-                          {{inv.balance}} {{inv.charges.freightFee.currency}}
-                        </span>
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
-                        <span *ngIf="inv.invType==='manual'">
                           {{inv.invDueDate | date : 'yyyy/MM/dd'}}
-                        </span>
+
                       </td>
                       <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                         <span *ngIf="inv.invStatus !== 'overdue'"

--- a/src/app/pages/accounts/invoices/invoice-list/invoice-list.component.ts
+++ b/src/app/pages/accounts/invoices/invoice-list/invoice-list.component.ts
@@ -34,7 +34,7 @@ export class InvoiceListComponent implements OnInit {
   emailedOrderInvoices = [];
   partiallyPaidOrderInvoices = [];
   voidedOrderInvoices = [];
-
+  invGenStatus: boolean;
   filter = {
     startDate: null,
     endDate: null,
@@ -49,6 +49,9 @@ export class InvoiceListComponent implements OnInit {
   fetchInvoices() {
     this.accountService.getData('order-invoice').subscribe((res: any) => {
       this.orderInvoices = res;
+      this.orderInvoices.map((v: any) => {
+        v.invStatus = v.invStatus.replace('_', ' ');
+      });
       this.categorizeOrderInvoices(this.orderInvoices);
     });
 
@@ -162,9 +165,9 @@ export class InvoiceListComponent implements OnInit {
     this.invID = invID;
     $('#updateStatusModal').modal('show');
   }
-editFn(invID: string) {
-  this.router.navigateByUrl(`/accounts/invoices/edit/${invID}`);
-}
+  editFn(invID: string) {
+    this.router.navigateByUrl(`/accounts/invoices/edit/${invID}`);
+  }
   updateInvStatus() {
     this.accountService.getData(`invoices/status/${this.invID}/${this.invNewStatus}`).subscribe(() => {
       this.toaster.success('Invoice Status Updated Successfully.');
@@ -172,10 +175,10 @@ editFn(invID: string) {
       $('#updateStatusModal').modal('hide');
     });
   }
-   deleteOrderInvoice(invID: string, orderID: string) {
+  deleteOrderInvoice(invID: string, orderID: string) {
     this.accountService.deleteData(`order-invoice/delete/${invID}`).subscribe(() => {
-      const invStatus:boolean = false;
-      this.apiService.getData(`orders/invoiceStatus/${orderID}/${invStatus}`).subscribe((res) => {
+      this.invGenStatus = false;
+      this.apiService.getData(`orders/invoiceStatus/${orderID}/${this.invGenStatus}`).subscribe((res) => {
         if (res) {
           this.toaster.success('Invoice Deleted Successfully.');
         }
@@ -184,21 +187,43 @@ editFn(invID: string) {
     });
   }
 
- searchFilter() {
-    // if ( this.filter.endDate !== null || this.filter.startDate !== null || this.filter.invNo !== null) {
-    //   this.dataMessage = Constants.FETCHING_DATA;
-    //   console.log('this.filter.endDate', this.filter.endDate);
-    //   console.log('this.filter.startDate', this.filter.startDate);
-    //   console.log('this.filter.invNo', this.filter.invNo);
-    //   this.fetchDetails();
-    // }
+  searchFilter() {
+    if (this.filter.endDate !== null || this.filter.startDate !== null || this.filter.invNo !== null) {
+      this.dataMessage = Constants.FETCHING_DATA;
+      this.fetchDetails();
+    }
   }
 
   fetchDetails() {
     this.accountService.getData(`invoices/paging?invNo=${this.filter.invNo}&startDate=${this.filter.startDate}&endDate=${this.filter.endDate}`)
       .subscribe((result: any) => {
-        console.log(' fetched invoices', result);
-       //this.invoices = result[0];     
+        this.invoices = result;
       });
+    this.accountService.getData(`order-invoice/paging?invNo=${this.filter.invNo}&startDate=${this.filter.startDate}&endDate=${this.filter.endDate}`)
+      .subscribe((result: any) => {
+        this.orderInvoices = result;
+      });
+  }
+  resetFilter() {
+    this.dataMessage = Constants.FETCHING_DATA;
+    this.filter = {
+      startDate: null,
+      endDate: null,
+      invNo: null
+    };
+    this.total = 0;
+    this.openInvoices = [];
+    this.openTotal = 0;
+    this.paidInvoices = [];
+    this.paidTotal = 0;
+    this.emailedInvoices = [];
+    this.emailedTotal = 0;
+    this.partiallyPaidInvoices = [];
+    this.partiallyPaidTotal = 0;
+    this.voidedInvoices = [];
+    this.voidedTotal = 0;
+    this.invoices = [];
+    this.orderInvoices = [];
+    this.fetchInvoices();
   }
 }

--- a/src/app/pages/accounts/invoices/load-invoice-detail/load-invoice-detail.component.html
+++ b/src/app/pages/accounts/invoices/load-invoice-detail/load-invoice-detail.component.html
@@ -1,364 +1,426 @@
-<section class="body">
+<section class="body" *ngIf="showDetails">
   <div class="inner-wrapper">
     <section role="main" class="content-body pt-0 pr-0 pl-0">
       <header class="page-header">
         <div class="row pr-1 mr-1" style="padding-top:10px;">
           <div class="col-md-4 col-lg-4 font-weight-bold text-4 text-dark"> Invoice Details </div>
           <div class="col-md-8 col-lg-8 text-right pr-1">
-             <a routerLink="/accounts/invoices/list" class="btn btn-default btn-sm"><i class="fas fa-list"></i> All Invoices</a>
-           </div>
+            <a routerLink="/accounts/invoices/list" class="btn btn-default btn-sm"><i class="fas fa-list"></i> All
+              Invoices</a>
+          </div>
         </div>
       </header>
-        <div class="row text-dark">
-          <div class="col-lg-6 offset-lg-3">
-            <section class="invoice-wrapper p-0" style="background-color: #fff;">
-              <table width="100%">
-                  <tbody>
-                      <tr *ngIf="invoiceData.carrierData != undefined">
-                          <td>
-                              <table width="100%">
-                                  <tbody>
-                                      <tr>
-                                          <td width="60%" class="title" valign="middle"
-                                              style="padding: 10px;text-align: left;">
-                                              <h4
-                                                  style="margin: 0;font-size: 27px;color: #040404;font-weight: 700;text-transform: capitalize;">
-                                                  INVOICE</h4>
-                                          </td>
-                                          <td width="60%" class="title" valign="middle"
-                                              style="padding: 10px;text-align: right;">
-                                              <h4
-                                                  style="margin: 0;font-size: 20px;color: #040404;font-weight: 700;text-transform: capitalize;">
-                                                  {{invoiceData.carrierData.companyName}}</h4>
-                                              <h6 style="color: #040404;
+      <div class="row text-dark">
+        <div class="col-lg-6 offset-lg-3">
+          <section class="invoice-wrapper p-0" style="background-color: #fff;" *ngIf="invoiceData != undefined">
+            <table width="100%">
+              <tbody>
+                <tr>
+                  <td>
+                    <table width="100%">
+                      <tbody>
+                        <tr>
+                          <td width="60%" class="title" valign="middle" style="padding: 10px;text-align: left;">
+                            <h4
+                              style="margin: 0;font-size: 27px;color: #040404;font-weight: 700;text-transform: capitalize;">
+                              INVOICE</h4>
+                          </td>
+                          <td width="60%" class="title" valign="middle" style="padding: 10px;text-align: right;">
+                            <h4
+                              style="margin: 0;font-size: 20px;color: #040404;font-weight: 700;text-transform: capitalize;">
+                              {{invoiceData.carrierData.companyName}}</h4>
+                            <h6 style="color: #040404;
                                               font-weight: 500;
                                               width: 250px;
-                                              float: right;"
-                                                  class="m-0">{{invoiceData.carrierData.address}}</h6>
-                                          </td>
-                                      </tr>
-                                  </tbody>
+                                              float: right;" class="m-0">{{invoiceData.carrierData.address}}</h6>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td>
+                    <div class="p-2">
+                      <table width="100%" class="invoice-iner__wrapper" style="padding: 10px;">
+                        <tbody>
+                          <tr *ngIf="invoiceData.data != undefined">
+                            <td valign="top">
+                              <b style="font-size: 12px;">CUSTOMER:</b> <br>
+                              <span style="text-transform: capitalize;">
+                                {{invoiceData.data[0].customerData.companyName}} <br></span>
+                              {{invoiceData.data[0].customerData.address}} <br>
+                              <span
+                                *ngIf="invoiceData.data[0].customerData.additionalContact != '' && invoiceData.data[0].customerData.additionalContact != null ">
+                                Contact Person: <b
+                                  class="text-capitalize">{{invoiceData.data[0].customerData.additionalContact}}</b>
+                                <br></span>
+                              <span
+                                *ngIf="invoiceData.data[0].customerData.phone != '' && invoiceData.data[0].customerData.phone != null ">Phone:
+                                <b>{{invoiceData.data[0].customerData.phone}}</b></span>
+                            </td>
+                            <td align="right">
+                              <table>
+                                <tbody>
+                                  <tr>
+                                    <td align="right" style="padding: 0 0 10px">
+                                      <span style="font-size: 12px;text-transform: uppercase;">
+                                        <b>Invoice#</b> <br>
+                                      </span>
+                                      {{invoiceData.invNo}}
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <td align="right" style="padding: 0 0 10px">
+                                      <span style="font-size: 12px;text-transform: uppercase;">
+                                        <b>Invoice Date</b> <br>
+                                      </span>
+                                      {{invoiceData.created | date: 'yyyy/MM/dd'}}
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <td align="right" style="padding: 0 0 10px">
+                                      <span style="font-size: 12px;text-transform: uppercase;">
+                                        <b>Order#</b>
+                                      </span><br>
+                                      {{invoiceData.invNo}}
+                                    </td>
+                                  </tr>
+                                </tbody>
                               </table>
-                          </td>
-                      </tr>
-                      <tr>
-                            <td *ngFor="let item of invoiceData.data">
-                              <div class="p-2">
-                                  <table width="100%" class="invoice-iner__wrapper" style="padding: 10px;" *ngFor="let ship of item.shippers">
-                                      <tbody>
+                            </td>
+                          </tr>
+                          <tr>
+                            <td valign="top" colspan="2">
+                              <div *ngFor="let item of invoiceData.data">
+                                <div *ngFor="let ship of item.shippers"
+                                  style=" display: flex;width: 100%;float: left;justify-content: space-between;">
+                                  <div class="shipment__wrap"
+                                    style="padding: 5px; float: left; margin-bottom: 5px;width: 49.5%;border-style: dashed;border-width: 1px;border-color: #8d8d8d;">
+                                    <b style="font-size: 12px;">SHIPPER:</b> <br>
+                                    <span class="text-capitalize">{{ship.companyName}}</span> <br>
+                                    {{ship.shipAddress}}
+
+                                    <div *ngFor="let pick of ship.pickupPoint; let i = index;" class="pickup-item mt-2">
+                                      <p class="m-0 text-dark"><b>Pickup: {{i + 1}}</b> -
+                                        {{pick.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
+
+                                      <span *ngIf="pick.address.manual" style="width: 70%;display: inline-block;">
+                                        {{ pick.address.address }}
+                                        {{ pick.address.city }}
+                                        {{ pick.address.state }}
+                                        {{ pick.address.country }}
+                                        {{ pick.address.zipCode }}
+                                      </span>
+                                      <span *ngIf="!pick.address.manual" style="width: 70%;display: inline-block;">
+                                        {{ pick.address.pickupLocation }}
+                                      </span>
+                                      <p class="m-0 text-dark">Contact Person: <b
+                                          class="text-capitalize">{{pick.contactPerson}}</b></p>
+
+                                      <table width="100%" style="border-top: none;font-size: 12px;">
+                                        <tbody>
                                           <tr>
-                                              <td valign="top">
-                                                  <b style="font-size: 12px;">CUSTOMER:</b> <br>
-                                                  <span style="text-transform: capitalize;">
-                                                      {{item.customerData.companyName}} <br></span>
-                                                  {{item.customerData.address}} <br>
-                                                  <span
-                                                      *ngIf="item.customerData.additionalContact != '' && item.customerData.additionalContact != null ">
-                                                      Contact Person: <b class="text-capitalize">{{item.customerData.additionalContact}}</b> <br></span>
-                                                  <span
-                                                      *ngIf="item.customerData.phone != '' && item.customerData.phone != null ">Phone:
-                                                      <b>{{item.customerData.phone}}</b></span>
-                                              </td>
-                                              <td align="right">
-                                                  <table>
-                                                      <tbody>
-                                                          <tr>
-                                                              <td align="right" style="padding: 0 0 10px">
-                                                                  <span
-                                                                      style="font-size: 12px;text-transform: uppercase;">
-                                                                      <b>Invoice#</b> <br>
-                                                                  </span>
-                                                                  {{invoiceData.invNo}}
-                                                              </td>
-                                                          </tr>
-                                                          <tr>
-                                                              <td align="right" style="padding: 0 0 10px">
-                                                                  <span
-                                                                      style="font-size: 12px;text-transform: uppercase;">
-                                                                      <b>Invoice Date</b> <br>
-                                                                  </span>
-                                                                 {{invoiceData.created | date: 'yyyy/MM/dd'}}
-                                                              </td>
-                                                          </tr>
-                                                          <tr>
-                                                              <td align="right" style="padding: 0 0 10px">
-                                                                  <span
-                                                                      style="font-size: 12px;text-transform: uppercase;">
-                                                                      <b>Order#</b>
-                                                                  </span><br>
-                                                                  {{invoiceData.invNo}}
-                                                              </td>
-                                                          </tr>
-                                                      </tbody>
-                                                  </table>
-                                              </td>
+                                            <td colspan="6" style="padding: 5px 0;">
+                                              <table class="table-striped table-bordered" width="100%">
+                                                <thead>
+                                                  <tr style="font-size: 12px;">
+                                                    <td class="text-capitalize" colspan="2">COMMODITY</td>
+                                                    <td style="width: 80px">PICK#</td>
+                                                    <td style="width: 70px">QTY </td>
+                                                    <td style="width: 70px">WEIGHT</td>
+
+                                                  </tr>
+                                                </thead>
+                                                <tbody>
+                                                  <tr class="item" *ngFor="let commodity of pick.commodity;">
+                                                    <td colspan="2">{{commodity.name}}</td>
+                                                    <td>{{commodity.pu}}</td>
+                                                    <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
+                                                    <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
+
+                                                  </tr>
+
+
+                                                </tbody>
+                                              </table>
+                                            </td>
                                           </tr>
-                                          <tr >
-                                              <td valign="top" style="width: 50%;">
-                                                  <div  class="shipment__wrap" style=" border-style:dashed;   border-width: 1px ; border-color: #8d8d8d;
-                                                  padding: 10px;">
-                                                      <b style="font-size: 12px;">SHIPPER:</b> <br>
-                                                      <span class="text-capitalize">{{ship.companyName}}</span> <br>
-                                                      {{ship.shipAddress}}
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                  </div>
+                                  <div
+                                    style=" padding: 5px; margin-bottom: 5px;width: 49.5%;float: left;border: 1px dashed #8d8d8d;">
+                                    <div *ngFor="let receive of ship.receivers;"
+                                      [ngClass]="{'border-bottom pb-2 mb-2': ship.receivers?.length > 1}">
+                                      <b style="font-size: 12px;">RECEIVER:</b> <br>
+                                      <span class="text-capitalize">{{receive.companyName}}</span>
+                                      <br>
+                                      {{receive.receiverAddress}}
 
-                                                      <div *ngFor="let pick of ship.pickupPoint; let i = index;" class="pickup-item mt-2">
-                                                          <p class="m-0 text-dark"><b>Pickup: {{i + 1}}</b> - {{pick.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
+                                      <div *ngFor="let drop of receive.dropPoint; let j = index;"
+                                        class="pickup-item mt-2">
+                                        <p class="m-0 text-dark"><b>Drop: {{j + 1}}</b> -
+                                          {{drop.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
 
-                                                          <span *ngIf="pick.address.manual" style="width: 70%;display: inline-block;">
-                                                              {{ pick.address.address }}
-                                                              {{ pick.address.city }}
-                                                              {{ pick.address.state }}
-                                                              {{ pick.address.country }}
-                                                              {{ pick.address.zipCode }}
-                                                          </span>
-                                                          <span *ngIf="!pick.address.manual" style="width: 70%;display: inline-block;">
-                                                              {{ pick.address.pickupLocation }}
-                                                          </span>
-                                                          <p class="m-0 text-dark">Contact Person: <b class="text-capitalize">{{pick.contactPerson}}</b></p>
+                                        <span *ngIf="drop.address.manual" style="width: 70%;display: inline-block;">
+                                          {{ drop.address.address }}
+                                          {{ drop.address.city }}
+                                          {{ drop.address.state }}
+                                          {{ drop.address.country }}
+                                          {{ drop.address.zipCode }}
+                                        </span>
+                                        <span *ngIf="!drop.address.manual" style="width: 70%;display: inline-block;">
+                                          {{ drop.address.dropOffLocation }}
+                                        </span>
+                                        <p class="m-0 text-dark">Contact Person:
+                                          <b>{{drop.contactPerson}}</b></p>
 
-                                                          <table width="100%" style="border-top: none;font-size: 12px;">
-                                                              <tbody>
-                                                                  <tr>
-                                                                      <td colspan="6" style="padding: 5px 0;">
-                                                                          <table class="table-striped table-bordered" width="100%">
-                                                                              <thead>
-                                                                                  <tr style="font-size: 12px;">
-                                                                                      <td class="text-capitalize" colspan="2">COMMODITY</td>
-                                                                                      <td style="width: 80px">PICK#</td>
-                                                                                      <td style="width: 70px">QTY </td>
-                                                                                      <td style="width: 70px">WEIGHT</td>
-                                                                                  </tr>
-                                                                              </thead>
-                                                                              <tbody>
-                                                                                  <tr class="item" *ngFor="let commodity of pick.commodity;">
-                                                                                      <td colspan="2">{{commodity.name}}</td>
-                                                                                      <td>{{commodity.pu}}</td>
-                                                                                      <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
-                                                                                      <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
-                                                                                  </tr>
-                                                                              </tbody>
-                                                                          </table>
-                                                                      </td>
-                                                                  </tr>
-                                                              </tbody>
-                                                          </table>
-                                                      </div>
-                                                  </div>
+                                        <table width="100%" style="border-top: none;font-size: 12px;">
+                                          <tbody>
+                                            <tr>
+                                              <td colspan="6" style="padding: 5px 0;">
+                                                <table class="table-striped table-bordered" width="100%">
+                                                  <thead>
+                                                    <tr style="font-size: 12px;">
+                                                      <td colspan="2">COMMODITY</td>
+                                                      <td style="width: 80px">DEL#</td>
+                                                      <td style="width: 70px">QTY </td>
+                                                      <td style="width: 70px">WEIGHT</td>
+
+                                                    </tr>
+                                                  </thead>
+                                                  <tbody>
+                                                    <tr class="item" *ngFor="let commodity of drop.commodity;">
+                                                      <td class="text-capitalize" colspan="2">
+                                                        {{commodity.name}}</td>
+                                                      <td>{{commodity.del}}</td>
+                                                      <td>{{commodity.quantity}}
+                                                        {{commodity.quantityUnit}}</td>
+                                                      <td>{{commodity.weight}}
+                                                        {{commodity.weightUnit}}</td>
+
+                                                    </tr>
+
+
+                                                  </tbody>
+                                                </table>
                                               </td>
-
-                                              <td valign="top" align="right" style="width: 50%;">
-                                                  <div *ngFor="let receive of ship.receivers;" style="    border: 1px dashed #8d8d8d;
-                                                  padding: 10px;">
-                                                      <b style="font-size: 12px;">RECEIVER:</b> <br>
-                                                      <span class="text-capitalize">{{receive.companyName}}</span> <br>
-                                                      {{receive.receiverAddress}}
-
-                                                      <div *ngFor="let drop of receive.dropPoint; let j = index;" class="pickup-item mt-2">
-                                                          <p class="m-0 text-dark"><b>Drop: {{j + 1}}</b> - {{drop.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
-
-                                                          <span *ngIf="drop.address.manual" style="width: 70%;display: inline-block;">
-                                                              {{ drop.address.address }}
-                                                              {{ drop.address.city }}
-                                                              {{ drop.address.state }}
-                                                              {{ drop.address.country }}
-                                                              {{ drop.address.zipCode }}
-                                                          </span>
-                                                          <span *ngIf="!drop.address.manual" style="width: 70%;display: inline-block;">
-                                                              {{ drop.address.dropOffLocation }}
-                                                          </span>
-                                                          <p class="m-0 text-dark">Contact Person: <b>{{drop.contactPerson}}</b></p>
-
-                                                          <table width="100%" style="border-top: none;font-size: 12px;">
-                                                              <tbody>
-                                                                  <tr>
-                                                                      <td colspan="6" style="padding: 5px 0;">
-                                                                          <table class="table-striped table-bordered" width="100%">
-                                                                              <thead>
-                                                                                  <tr style="font-size: 12px;">
-                                                                                      <td colspan="2">COMMODITY</td>
-                                                                                      <td style="width: 80px">DEL#</td>
-                                                                                      <td style="width: 70px">QTY </td>
-                                                                                      <td style="width: 70px">WEIGHT</td>
-
-                                                                                  </tr>
-                                                                              </thead>
-                                                                              <tbody>
-                                                                                  <tr class="item" *ngFor="let commodity of drop.commodity;">
-                                                                                      <td class="text-capitalize" colspan="2">{{commodity.name}}</td>
-                                                                                      <td>{{commodity.del}}</td>
-                                                                                      <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
-                                                                                      <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
-                                                                                  </tr>
-                                                                              </tbody>
-                                                                          </table>
-                                                                      </td>
-                                                                  </tr>
-                                                              </tbody>
-                                                          </table>
-                                                      </div>
-                                                  </div>
-                                              </td>
-                                          </tr>
-                                      </tbody>
-                                      <div *ngIf="item.shippers?.length > 1" class="html2pdf__page-break"></div>
-                                  </table>
-
-                                  <table class="invoice-iner__wrapper" width="100%" style="border-top: none;">
-                                      <tbody>
-                                          <tr>
-                                              <td colspan="6">
-                                                  <table class="table-striped table-bordered" width="100%">
-                                                      <thead>
-                                                          <tr style="font-size: 12px;">
-                                                              <td colspan="6">FEE METHOD</td>
-
-                                                              <td style="width: 100px" align="right">TOTAL</td>
-                                                          </tr>
-                                                      </thead>
-                                                      <tbody>
-
-                                                          <tr *ngIf="invoiceData.charges.freightFee.type != '' || invoiceData.charges.freightFee.type != null || invoiceData.charges.freightFee.type != undefined">
-                                                              <td colspan="8" style="padding: 0;">
-                                                                  <table style="width: 100%;">
-                                                                      <tbody>
-                                                                          <tr class="item">
-                                                                              <td colspan="6">{{invoiceData.charges.freightFee.type}}
-                                                                                  <small>(Freight Fees)</small></td>
-
-                                                                              <td align="right">
-                                                                                  {{invoiceData.charges.freightFee.amount}}
-                                                                                  <small>{{invoiceData.charges.freightFee.currency}}</small>
-                                                                              </td>
-                                                                          </tr>
-                                                                      </tbody>
-                                                                  </table>
-                                                              </td>
-                                                          </tr>
-                                                          <tr *ngIf="invoiceData.charges.fuelSurcharge.type != null">
-                                                              <td colspan="8" style="padding: 0;">
-                                                                  <table style="width: 100%;">
-                                                                      <tbody>
-                                                                          <tr>
-                                                                              <td colspan="6">
-                                                                                  {{invoiceData.charges.fuelSurcharge.type}}<small>
-                                                                                      (Fuel Surcharge)</small></td>
-
-                                                                              <td align="right">
-                                                                                  {{invoiceData.charges.fuelSurcharge.amount}}
-                                                                                  <small>{{invoiceData.charges.fuelSurcharge.currency}}</small>
-                                                                              </td>
-
-                                                                          </tr>
-                                                                      </tbody>
-                                                                  </table>
-                                                              </td>
-                                                          </tr>
-
-                                                          <tr *ngIf="invoiceData.charges.accessorialFeeInfo.total != 0">
-                                                              <td colspan="8" style="padding: 0;">
-                                                                  <table style="width: 100%;">
-                                                                      <tbody>
-                                                                          <tr
-                                                                              *ngFor="let item of invoiceData.charges.accessorialFeeInfo.accessorialFee;">
-                                                                              <td colspan="6">{{item.type}} <small>(Accessorial
-                                                                                Addition)</small></td>
-                                                                              <td align="right">{{invoiceData.charges.accessorialFeeInfo.total}}
-                                                                                  <small>{{item.currency}}</small></td>
-                                                                          </tr>
-                                                                      </tbody>
-                                                                  </table>
-                                                              </td>
-                                                          </tr>
-                                                          <tr *ngIf="invoiceData.charges.accessorialDeductionInfo.total != 0">
-                                                              <td colspan="8" style="padding: 0;">
-                                                                  <table style="width: 100%;">
-                                                                      <tbody>
-                                                                          <tr
-                                                                          *ngFor="let item of invoiceData.charges.accessorialDeductionInfo.accessorialDeduction;">
-                                                                          <td colspan="6">{{item.type}} <small>(Accessorial
-                                                                                  Deduction)</small></td>
-                                                                          <td align="right">- {{invoiceData.charges.accessorialDeductionInfo.total}}
-                                                                              <small>{{item.currency}}</small></td>
-
-                                                                      </tr>
-                                                                      </tbody>
-                                                                  </table>
-                                                              </td>
-                                                          </tr>
-
-
-                                                          <tr class="bg-transparent">
-                                                              <td align="right" colspan="6">Sub Total</td>
-                                                              <td align="right">{{invoiceData.subTotal}}
-                                                                  <small>{{invoiceData.charges.freightFee.currency}} </small></td>
-                                                          </tr>
-                                                          <tr class="bg-transparent">
-                                                              <td colspan="6" align="right">Tax</td>
-                                                              <td align="right">{{invoiceData.taxesAmt}}
-                                                                  <small>{{invoiceData.charges.freightFee.currency}} </small></td>
-                                                          </tr>
-
-                                                      </tbody>
-                                                      <tfoot class="border-1">
-                                                          <tr>
-                                                              <th colspan="6" align="right">
-                                                                  <div style="text-align: right;">
-                                                                      TOTAL
-                                                                  </div>
-                                                              </th>
-                                                              <th align="right">
-                                                                  <div style="text-align: right;">
-                                                                      {{invoiceData.finalAmount}}
-                                                                      <small>{{invoiceData.charges.freightFee.currency}} </small>
-                                                                  </div>
-                                                              </th>
-                                                          </tr>
-                                                      </tfoot>
-                                                  </table>
-                                              </td>
-                                          </tr>
-                                      </tbody>
-                                  </table>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
 
-                          </td>
-                      </tr>
-                  </tbody>
-              </table>
-          </section>
-          <section class="mt-5 bg-white p-2"  *ngIf="invoiceData != undefined">
-            <p class="font-weight-bold text-5">Journal Details</p>
-              <div class="col-xl-12 col-12 mb-3">
-                <table class="table table-bordered table-hover">
-                  <thead>
+                      <table class="invoice-iner__wrapper" width="100%" style="border-top: none;">
+                        <tbody>
+                          <tr>
+                            <td colspan="6">
+                              <table class="table-striped table-bordered" width="100%">
+                                <thead>
+                                  <tr style="font-size: 12px;">
+                                    <td colspan="6">FEE METHOD</td>
+
+                                    <td style="width: 100px" align="right">TOTAL</td>
+                                  </tr>
+                                </thead>
+                                <tbody>
+
+                                  <tr
+                                    *ngIf="invoiceData != '' || invoiceData != null || invoiceData != undefined">
+                                    <td colspan="8" style="padding: 0;">
+                                      <table style="width: 100%;">
+                                        <tbody>
+                                          <tr class="item">
+                                            <td colspan="6">{{invoiceData.charges.freightFee.type}}
+                                              <small>(Freight Fees)</small></td>
+
+                                            <td align="right">
+                                              {{invoiceData.charges.freightFee.amount}}
+                                              <small>{{invoiceData.charges.freightFee.currency}}</small>
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </td>
+                                  </tr>
+                                  <tr *ngIf="invoiceData.charges.fuelSurcharge.type != null && invoiceData != undefined" >
+                                    <td colspan="8" style="padding: 0;" >
+                                      <table style="width: 100%;">
+                                        <tbody>
+                                          <tr>
+                                            <td colspan="6">
+                                              {{invoiceData.charges.fuelSurcharge.type}}<small>
+                                                (Fuel Surcharge)</small></td>
+
+                                            <td align="right">
+                                              {{invoiceData.charges.fuelSurcharge.amount}}
+                                              <small>{{invoiceData.charges.fuelSurcharge.currency}}</small>
+                                            </td>
+
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </td>
+                                  </tr>
+
+                                  <tr *ngIf="invoiceData.charges.accessorialFeeInfo.total != 0">
+                                    <td colspan="8" style="padding: 0;">
+                                      <table style="width: 100%;">
+                                        <tbody>
+                                          <tr
+                                            *ngFor="let item of invoiceData.charges.accessorialFeeInfo.accessorialFee;">
+                                            <td colspan="6">{{item.type}} <small>(Accessorial
+                                                Addition)</small></td>
+                                            <td align="right">{{invoiceData.charges.accessorialFeeInfo.total}}
+                                              <small>{{item.currency}}</small></td>
+
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </td>
+                                  </tr>
+                                  <tr *ngIf="invoiceData.charges.accessorialDeductionInfo.total != 0">
+                                    <td colspan="8" style="padding: 0;">
+                                      <table style="width: 100%;">
+                                        <tbody>
+                                          <tr
+                                            *ngFor="let item of invoiceData.charges.accessorialDeductionInfo.accessorialDeduction;">
+                                            <td colspan="6">{{item.type}} <small>(Accessorial
+                                                Deduction)</small></td>
+                                            <td align="right">- {{invoiceData.charges.accessorialDeductionInfo.total}}
+                                              <small>{{item.currency}}</small></td>
+
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </td>
+                                  </tr>
+
+
+                                  <tr class="bg-transparent">
+                                    <td align="right" colspan="6">Sub Total</td>
+                                    <td align="right">{{invoiceData.subTotal}}
+                                      <small>{{invoiceData.charges.freightFee.currency}} </small></td>
+                                  </tr>
+                                  <tr class="bg-transparent">
+                                    <td colspan="6" align="right">Tax</td>
+                                    <td align="right">{{invoiceData.taxesAmt}}
+                                      <small>{{invoiceData.charges.freightFee.currency}} </small></td>
+                                  </tr>
+
+                                </tbody>
+                                <tfoot class="border-1">
+                                  <tr>
+                                    <th colspan="6" align="right">
+                                      <div style="text-align: right;">
+                                        TOTAL
+                                      </div>
+                                    </th>
+                                    <th align="right">
+                                      <div style="text-align: right;">
+                                        {{invoiceData.finalAmount}}
+                                        <small>{{invoiceData.charges.freightFee.currency}} </small>
+                                      </div>
+                                    </th>
+                                  </tr>
+                                </tfoot>
+                              </table>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+
+                  </td>
+                </tr>
+                <!-- <tr>
+                <td colspan="6" style="padding-top: 20px;">
+                    <table>
+                        <tbody><tr>
+                            <td><b style="font-size: 12px;">INSTRUCTIONS:</b></td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <ol style="margin: 0; padding-left: 15px; ">
+                                    <li>Please ensure driver identifies himself as p/u on behalf of total logistics</li>
+                                    <li>Driver must be able and willing to provide either company photo id or another piece of suitable picture identification upon shipper/receiver request</li>
+                                    <li> All drivers are required to have safety shoes and vest</li>
+                                    <li>Please note that all food products are subject to fda review and therefore all drivers must report to the fda office at the time of crossing</li>
+                                </ol>
+                            </td>
+                        </tr>
+                    </tbody></table>
+                </td>
+            </tr> -->
+
+                <!-- <tr>
+            <td colspan="6" style="padding-top: 20px;">
+                <table>
+                    <tbody><tr>
+                        <td><b style="font-size: 12px;">TERMS:</b></td>
+                    </tr>
                     <tr>
-                      <th>Account Name</th>
-                      <th>Name</th>
-                      <th>Type</th>
-                      <th>Debit</th>
-                      <th>Credit</th>
+                        <td>
+                            <ol style="margin: 0; padding-left: 15px; ">
+                                <li>Invoice with all paperwork has to be sent to apinvoice@totallogistics.Com</li>
+                                <li>Time in &amp; out required for pick-up and delivery</li>
+                                <li>Third party billing by total logistics control</li>
+                                <li>All trailers must arrive at receiver’s sealed - ftl’s sealed and ltl‘s sealed or padlocked</li>
+                                <li>Fuel surcharge included in all rates</li>
+                                <li>All trailers must be 53' in length with barn doors, food grade, odour-free, dry and clean</li>
+                                <li>Do not mix with hazmat or toxic materials</li>
+                            </ol>
+                        </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    <tr *ngFor="let dt of invoiceData.transactionLog">
-                      <td><span *ngIf="dt.actIDType === 'actID'">{{accountsObjects[dt.accountID]}}</span>
-                         <span *ngIf="dt.actIDType === 'actIntID'">{{accountsIntObjects[dt.accountID]}}</span></td>
-                      <td>{{customersObjects[dt.name]}}</td>
-                      <td>{{dt.type | titlecase}}</td>
-                      <td><span *ngIf="dt.trxType === 'debit'">{{dt.amount}}&nbsp; {{dt.currency}}</span></td>
-                      <td><span *ngIf="dt.trxType === 'credit'">{{dt.amount}}&nbsp; {{dt.currency}}</span></td>
-                    </tr>
-                    <!-- <tr *ngIf="invoiceData.charges != undefined">
+                </tbody></table>
+            </td>
+        </tr> -->
+              </tbody>
+            </table>
+          </section>
+          <section class="mt-5 bg-white p-2" *ngIf="invoiceData != undefined">
+            <p class="font-weight-bold text-5">Journal Details</p>
+            <div class="col-xl-12 col-12 mb-3">
+              <table class="table table-bordered table-hover">
+                <thead>
+                  <tr>
+                    <th>Account Name</th>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Debit</th>
+                    <th>Credit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let dt of invoiceData.transactionLog">
+                    <td><span *ngIf="dt.actIDType === 'actID'">{{accountsObjects[dt.accountID]}}</span>
+                      <span *ngIf="dt.actIDType === 'actIntID'">{{accountsIntObjects[dt.accountID]}}</span></td>
+                    <td>{{customersObjects[dt.name]}}</td>
+                    <td>{{dt.type | titlecase}}</td>
+                    <td><span *ngIf="dt.trxType === 'debit'">{{dt.amount}}&nbsp; {{dt.currency}}</span></td>
+                    <td><span *ngIf="dt.trxType === 'credit'">{{dt.amount}}&nbsp; {{dt.currency}}</span></td>
+                  </tr>
+                  <!-- <tr *ngIf="invoiceData.charges != undefined">
                       <td colspan="3" class="font-weight-bold text-right">Total</td>
                       <td>{{invoiceData.finalAmount}} {{invoiceData.charges.freightFee.currency}}</td>
                       <td>{{invoiceData.finalAmount}} {{invoiceData.charges.freightFee.currency}}</td>
                     </tr> -->
-                  </tbody>
-                </table>
-              </div>
+                </tbody>
+              </table>
+            </div>
           </section>
-          </div>
         </div>
+      </div>
     </section>
   </div>
 </section>

--- a/src/app/pages/accounts/invoices/load-invoice-detail/load-invoice-detail.component.ts
+++ b/src/app/pages/accounts/invoices/load-invoice-detail/load-invoice-detail.component.ts
@@ -8,6 +8,7 @@ import { AccountService, ApiService } from '../../../../services';
 })
 export class LoadInvoiceDetailComponent implements OnInit {
   invID = '';
+  showDetails = false;
   invoiceData: any = {};
   customersObjects = {};
   accountsObjects = {};
@@ -25,6 +26,9 @@ export class LoadInvoiceDetailComponent implements OnInit {
   }
   fetchInvoice() {
     this.accountService.getData(`order-invoice/detail/${this.invID}`).subscribe((res) => {
+      if (res) {
+        this.showDetails = true;
+      }
       this.invoiceData = res[0];
       this.invoiceData.transactionLog.map((v: any) => {
         v.type = v.type.replace('_', ' ');

--- a/src/app/pages/accounts/receipts/receipts-list/receipts-list.component.html
+++ b/src/app/pages/accounts/receipts/receipts-list/receipts-list.component.html
@@ -4,33 +4,37 @@
       <header class="page-header">
               <form class="form-horizontal" method="get">
              <div class="row" style="padding-top:10px;">
-                <div class="col-md-2 col-lg-2">
-                   <div class="input-group input-group-md mb-3">
-                    <input type="text" class="form-control" placeholder="Search">
-                   </div>
+              <div class="col-md-2 col-lg-2">
+                <div class="input-group input-group-md mb-3">
+                  <input type="text" class="form-control" placeholder="Search" [(ngModel)]="filter.recNo" name="recNo">
                 </div>
-
-                <div class="col-lg-3 col-md-3">
-                   <div class="input-daterange input-group" data-plugin-datepicker>
-                      <span class="input-group-prepend">
-                         <span class="input-group-text">
-                            <i class="fas fa-calendar-alt"></i>
-                         </span>
+              </div>
+              <div class="col-lg-3 col-md-3">
+                <div class="input-daterange input-group">
+                   <span class="input-group-prepend">
+                      <span class="input-group-text">
+                         <i class="fas fa-calendar-alt"></i>
                       </span>
-                      <input type="text" class="form-control" name="start">
-                      <span class="input-group-text border-left-0 border-right-0 rounded-0">
-                         to
-                      </span>
-                      <input type="text" class="form-control" name="end">
-                   </div>
-                   </div>
-
-                <div class="col-md-1  col-lg-1">
-                          <button type="submit" class="btn btn-sm btn-success">Search</button>
-                         </div>
-                <div class="col-md-6  col-lg-6 text-right pr-5">
+                   </span>
+                   <input [(ngModel)]="filter.startDate" name="startDate"
+                      type="text" placeholder="yyyy/mm/dd" (click)="startDate.toggle()"
+                      ngbDatepicker #startDate="ngbDatepicker" class="form-control"
+                      autocomplete="off">
+                   <span class="input-group-text border-left-0 border-right-0 rounded-0">
+                      to
+                   </span>
+                   <input [(ngModel)]="filter.endDate" name="endDate"
+                      type="text" placeholder="yyyy/mm/dd" (click)="endDate.toggle()"
+                      ngbDatepicker #endDate="ngbDatepicker" class="form-control"
+                      autocomplete="off">
+                </div>
+             </div>
+              <div class="col-md-2  col-lg-2">
+                <button type="button" class="btn btn-sm btn-success" (click)="searchFilter()">Search</button>
+                <button type="button" class="btn btn-sm btn-success ml-1" (click)="resetFilter()">Reset</button>
+              </div>
+                <div class="col-md-5  col-lg-5 text-right pr-5">
                    <a routerLink="/accounts/receipts/add" class="btn btn-success btn-sm ml-2" style="color:white;"><i class="fas fa-plus"></i> Receive Payment </a>
-
                 </div>
              </div>
              </form>
@@ -55,7 +59,7 @@
                       </thead>
                       <tbody>
                         <tr *ngIf="receipts.length == 0" class="text-center">
-                          <td colspan="9">{{ noReceiptsMsg }}</td>
+                          <td colspan="9">{{ dataMessage }}</td>
                       </tr>
                          <tr *ngFor="let rec of receipts">
                             <td class="cursorpoint" routerLink="/accounts/receipts/detail/{{rec.recID}}">{{rec.txnDate}}</td>

--- a/src/app/pages/accounts/receipts/receipts-list/receipts-list.component.ts
+++ b/src/app/pages/accounts/receipts/receipts-list/receipts-list.component.ts
@@ -3,17 +3,23 @@ import { Component, OnInit } from '@angular/core';
 
 import { AccountService, ApiService } from './../../../../services';
 import { ToastrService } from 'ngx-toastr';
+import Constants from '../../../fleet/constants';
 @Component({
   selector: 'app-receipts-list',
   templateUrl: './receipts-list.component.html',
   styleUrls: ['./receipts-list.component.css']
 })
 export class ReceiptsListComponent implements OnInit {
-  noReceiptsMsg = 'No Data Found';
-  dataMessage: string;
+  dataMessage = Constants.NO_RECORDS_FOUND;
   receipts = [];
   customersObjects: any = {};
   accountsObject: any = {};
+
+  filter = {
+    startDate: null,
+    endDate: null,
+    recNo: null
+  };
   constructor(private accountService: AccountService, private toastr: ToastrService, private apiService: ApiService, ) {}
 
   ngOnInit() {
@@ -47,5 +53,27 @@ export class ReceiptsListComponent implements OnInit {
         .subscribe((result: any) => {
           this.accountsObject = result;
         });
+    }
+    searchFilter() {
+      if ( this.filter.endDate !== null || this.filter.startDate !== null || this.filter.recNo !== null) {
+        this.dataMessage = Constants.FETCHING_DATA;
+        this.fetchDetails();
+      }
+    }
+
+    fetchDetails() {
+      this.accountService.getData(`receipts/paging?recNo=${this.filter.recNo}&startDate=${this.filter.startDate}&endDate=${this.filter.endDate}`)
+        .subscribe((result: any) => {
+          this.receipts = result;
+        });
+    }
+    resetFilter() {
+      this.dataMessage = Constants.FETCHING_DATA;
+      this.filter = {
+        startDate: null,
+        endDate: null,
+        recNo: null
+      };
+      this.fetchReceipts();
     }
 }

--- a/src/app/pages/dispatch/orders/order-detail/order-detail.component.html
+++ b/src/app/pages/dispatch/orders/order-detail/order-detail.component.html
@@ -132,7 +132,7 @@
                                             </div>
                                             <div class="col-lg-9 p-2">{{ customerEmail }}</div>
                                         </div>
-                                        
+
                                     </div>
                                 </div>
 
@@ -282,7 +282,7 @@
                                                                                                     {{pick.address.zipCode}}
                                                                                                 </span>
                                                                                             </p>
-                                                                                            
+
                                                                                             <p class="mb-0 text-dark">
                                                                                                 <strong>Pickup
                                                                                                     Date/Time:</strong>
@@ -307,7 +307,7 @@
                                                                                                 class="table table-responsive-lg table-bordered table-striped table-sm mt-3 mb-0">
                                                                                                 <thead>
                                                                                                     <tr>
-        
+
                                                                                                         <th>Sr. No.</th>
                                                                                                         <th>Commodity</th>
                                                                                                         <th>PU#</th>
@@ -330,13 +330,13 @@
                                                                                                             {{commodity.weightUnit}}
                                                                                                         </td>
                                                                                                     </tr>
-        
+
                                                                                             </table>
                                                                                         </div>
                                                                                     </div>
                                                                                 </div>
                                                                         </div>
-                                                                       
+
                                                                     </div>
                                                                 </section>
                                                                 <p class="mb-0 text-dark">
@@ -400,25 +400,25 @@
                                                                                                 {{drop.address.zipCode}}
                                                                                             </span>
                                                                                         </p>
-                                                                                        
-                                                                                        
+
+
                                                                                         <p class="mb-0 text-dark">
                                                                                             <strong>Delivery Date/Time:</strong>
                                                                                             {{drop.dateAndTime
                                                                                             | date:'yyyy/MM/dd hh:mm a'}}
-                                                                                            
+
                                                                                         </p>
                                                                                         <p class="mb-0 text-dark">
                                                                                             <strong>Delivery
                                                                                                 Instruction:</strong>
                                                                                             {{drop.dropOffInstruction ? drop.dropOffInstruction : '-'}}
-        
+
                                                                                         </p>
                                                                                         <p class="mb-0 text-dark">
                                                                                             <strong>Contact Person at
                                                                                                 Delivery</strong>
                                                                                             {{drop.contactPerson ? drop.contactPerson : '-'}}
-        
+
                                                                                         </p>
                                                                                         <p class="mb-0 text-dark">
                                                                                             <strong>Phone:</strong>
@@ -428,7 +428,7 @@
                                                                                             class="table table-responsive-lg table-bordered table-striped table-sm mt-3 mb-0">
                                                                                             <thead>
                                                                                                 <tr>
-        
+
                                                                                                     <th>Sr. No.</th>
                                                                                                     <th>Commodity</th>
                                                                                                     <th>DEL#</th>
@@ -449,15 +449,15 @@
                                                                                                         {{commodity.weightUnit}}
                                                                                                     </td>
                                                                                                 </tr>
-        
+
                                                                                         </table>
                                                                                     </div>
-                                                                                    
-                                                                                    
+
+
                                                                                 </div>
                                                                             </div>
                                                                         </div>
-                                                                        
+
                                                                     </div>
                                                                 </section>
                                                                 <p class="mb-0 text-dark">
@@ -570,7 +570,7 @@
                                                                         <h5 class="m-0 text-dark"><strong>Shipper-{{i + 1}}</strong></h5>
                                                                         <div
                                                                             *ngFor="let point of ship.pickupPoint; let s=index">
-                                                                            Pickup-{{s + 1}}: 
+                                                                            Pickup-{{s + 1}}:
                                                                             <span *ngIf="point.address.manual">
                                                                                 {{ point.address.address }}
                                                                                 {{ point.address.city }}
@@ -593,7 +593,7 @@
                                                                         <h5 class="m-0 text-dark"><strong>Receiver-{{r + 1}}</strong></h5>
                                                                         <div
                                                                             *ngFor="let drop of rec.dropPoint; let s = index;">
-                                                                             Drop-{{s + 1}}: 
+                                                                             Drop-{{s + 1}}:
                                                                             <span *ngIf="drop.address.manual">
                                                                                 {{ drop.address.address }}
                                                                                 {{ drop.address.city }}
@@ -976,10 +976,10 @@
                                                                     <b style="font-size: 12px;">SHIPPER:</b> <br>
                                                                     <span class="text-capitalize">{{ship.companyName}}</span> <br>
                                                                     {{ship.shipAddress}}
-            
+
                                                                     <div *ngFor="let pick of ship.pickupPoint; let i = index;" class="pickup-item mt-2">
                                                                         <p class="m-0 text-dark"><b>Pickup: {{i + 1}}</b> - {{pick.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
-                                                                        
+
                                                                         <span *ngIf="pick.address.manual" style="width: 70%;display: inline-block;">
                                                                             {{ pick.address.address }}
                                                                             {{ pick.address.city }}
@@ -991,7 +991,7 @@
                                                                             {{ pick.address.pickupLocation }}
                                                                         </span>
                                                                         <p class="m-0 text-dark">Contact Person: <b class="text-capitalize">{{pick.contactPerson}}</b></p>
-                                                                        
+
                                                                         <table width="100%" style="border-top: none;font-size: 12px;">
                                                                             <tbody>
                                                                                 <tr>
@@ -1003,7 +1003,7 @@
                                                                                                     <td style="width: 80px">PICK#</td>
                                                                                                     <td style="width: 70px">QTY </td>
                                                                                                     <td style="width: 70px">WEIGHT</td>
-                                                                                                
+
                                                                                                 </tr>
                                                                                             </thead>
                                                                                             <tbody>
@@ -1012,10 +1012,9 @@
                                                                                                     <td>{{commodity.pu}}</td>
                                                                                                     <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
                                                                                                     <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
-                                                                                                    
+
                                                                                                 </tr>
-                                                                                                
-                                    
+
                                                                                             </tbody>
                                                                                         </table>
                                                                                     </td>
@@ -1023,16 +1022,16 @@
                                                                             </tbody>
                                                                         </table>
                                                                     </div>
-                                                                </div>    
-                                                                
+                                                                </div>
+
                                                                 <div *ngFor="let receive of ship.receivers;" style=" padding: 5px; margin-bottom: 5px;width: 49.5%;float: left;border: 1px dashed #8d8d8d;">
                                                             <b style="font-size: 12px;">RECEIVER:</b> <br>
                                                             <span class="text-capitalize">{{receive.companyName}}</span> <br>
                                                             {{receive.receiverAddress}}
-    
+
                                                             <div *ngFor="let drop of receive.dropPoint; let j = index;" class="pickup-item mt-2">
                                                                 <p class="m-0 text-dark"><b>Drop: {{j + 1}}</b> - {{drop.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
-                                                                
+
                                                                 <span *ngIf="drop.address.manual" style="width: 70%;display: inline-block;">
                                                                     {{ drop.address.address }}
                                                                     {{ drop.address.city }}
@@ -1044,7 +1043,7 @@
                                                                     {{ drop.address.dropOffLocation }}
                                                                 </span>
                                                                 <p class="m-0 text-dark">Contact Person: <b>{{drop.contactPerson}}</b></p>
-    
+
                                                                 <table width="100%" style="border-top: none;font-size: 12px;">
                                                                     <tbody>
                                                                         <tr>
@@ -1056,7 +1055,7 @@
                                                                                             <td style="width: 80px">DEL#</td>
                                                                                             <td style="width: 70px">QTY </td>
                                                                                             <td style="width: 70px">WEIGHT</td>
-                                                                                           
+
                                                                                         </tr>
                                                                                     </thead>
                                                                                     <tbody>
@@ -1065,10 +1064,10 @@
                                                                                             <td>{{commodity.del}}</td>
                                                                                             <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
                                                                                             <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
-                                                                                            
+
                                                                                         </tr>
-                                                                                        
-                            
+
+
                                                                                     </tbody>
                                                                                 </table>
                                                                             </td>
@@ -1076,22 +1075,22 @@
                                                                     </tbody>
                                                                 </table>
                                                             </div>
-                                                        </div>    
-                                                            </div>
-                                                            
                                                         </div>
-                                                        
-                                                        
-                                                       
-                                                        
+                                                            </div>
+
+                                                        </div>
+
+
+
+
                                                     </td>
-    
-                                                    
+
+
                                                 </tr>
                                             </tbody>
-                                            
+
                                         </table>
-                                       
+
                                         <table class="invoice-iner__wrapper" width="100%" style="border-top: none;">
                                             <tbody>
                                                 <tr>
@@ -1100,12 +1099,12 @@
                                                             <thead>
                                                                 <tr style="font-size: 12px;">
                                                                     <td colspan="6">FEE METHOD</td>
-                                                                   
+
                                                                     <td style="width: 100px" align="right">TOTAL</td>
                                                                 </tr>
                                                             </thead>
                                                             <tbody>
-                                                                
+
                                                                 <tr *ngIf="invoiceData.charges.freightFee.type != '' || invoiceData.charges.freightFee.type != null">
                                                                     <td colspan="8" style="padding: 0;">
                                                                         <table style="width: 100%;">
@@ -1113,7 +1112,7 @@
                                                                                 <tr class="item">
                                                                                     <td colspan="6">{{invoiceData.charges.freightFee.type}}
                                                                                         <small>(Freight Fees)</small></td>
-                                                                                    
+
                                                                                     <td align="right">
                                                                                         {{invoiceData.charges.freightFee.amount}}
                                                                                         <small>{{invoiceData.charges.freightFee.currency}}</small>
@@ -1131,18 +1130,18 @@
                                                                                     <td colspan="6">
                                                                                         {{invoiceData.charges.fuelSurcharge.type}}<small>
                                                                                             (Fuel Surcharge)</small></td>
-                                                                                    
+
                                                                                     <td align="right">
                                                                                         {{invoiceData.charges.fuelSurcharge.amount}}
                                                                                         <small>{{invoiceData.charges.fuelSurcharge.currency}}</small>
                                                                                     </td>
-                    
+
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>
                                                                     </td>
                                                                 </tr>
-                                                                
+
                                                                 <tr *ngIf="invoiceData.charges.accessorialFeeInfo.accessorialFee[0].type != ''">
                                                                     <td colspan="8" style="padding: 0;">
                                                                         <table style="width: 100%;">
@@ -1153,7 +1152,7 @@
                                                                                             Surcharge)</small></td>
                                                                                     <td align="right">{{item.amount}}
                                                                                         <small>{{item.currency}}</small></td>
-                    
+
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>
@@ -1169,14 +1168,14 @@
                                                                                         Deduction)</small></td>
                                                                                 <td align="right">- {{item.amount}}
                                                                                     <small>{{item.currency}}</small></td>
-                
+
                                                                             </tr>
                                                                             </tbody>
                                                                         </table>
                                                                     </td>
                                                                 </tr>
-                                                                
-                                                                
+
+
                                                                 <tr class="bg-transparent">
                                                                     <td align="right" colspan="6">Sub Total</td>
                                                                     <td align="right">{{invoiceData.subTotal}}
@@ -1187,7 +1186,7 @@
                                                                     <td align="right">{{invoiceData.taxesAmt}}
                                                                         <small>{{charges.freightFee.currency}} </small></td>
                                                                 </tr>
-                                                               
+
                                                             </tbody>
                                                             <tfoot class="border-1">
                                                                 <tr>
@@ -1210,7 +1209,7 @@
                                             </tbody>
                                         </table>
                                     </div>
-                                    
+
                                 </td>
                             </tr>
                             <!-- <tr>
@@ -1261,7 +1260,7 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-default" data-dismiss="modal">Cancel</button>
-                <a href="javascript:;" (click)="generatePDF()" class="btn btn-success">Generate & Print</a>
+                <button [disabled]="generateBtnDisabled" (click)="generatePDF()" class="btn btn-success">Generate & Print</button>
             </div>
         </div>
     </div>
@@ -1362,10 +1361,10 @@
                                                             <b style="font-size: 12px;">SHIPPER:</b> <br>
                                                             <span class="text-capitalize">{{ship.companyName}}</span> <br>
                                                             {{ship.shipAddress}}
-    
+
                                                             <div *ngFor="let pick of ship.pickupPoint; let i = index;" class="pickup-item mt-2">
                                                                 <p class="m-0 text-dark"><b>Pickup: {{i + 1}}</b> - {{pick.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
-                                                                
+
                                                                 <span *ngIf="pick.address.manual" style="width: 70%;display: inline-block;">
                                                                     {{ pick.address.address }}
                                                                     {{ pick.address.city }}
@@ -1377,7 +1376,7 @@
                                                                     {{ pick.address.pickupLocation }}
                                                                 </span>
                                                                 <p class="m-0 text-dark">Contact Person: <b class="text-capitalize">{{pick.contactPerson}}</b></p>
-                                                                
+
                                                                 <table width="100%" style="border-top: none;font-size: 12px;">
                                                                     <tbody>
                                                                         <tr>
@@ -1389,7 +1388,7 @@
                                                                                             <td style="width: 80px">PICK#</td>
                                                                                             <td style="width: 70px">QTY </td>
                                                                                             <td style="width: 70px">WEIGHT</td>
-                                                                                           
+
                                                                                         </tr>
                                                                                     </thead>
                                                                                     <tbody>
@@ -1398,10 +1397,10 @@
                                                                                             <td>{{commodity.pu}}</td>
                                                                                             <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
                                                                                             <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
-                                                                                            
+
                                                                                         </tr>
-                                                                                        
-                            
+
+
                                                                                     </tbody>
                                                                                 </table>
                                                                             </td>
@@ -1410,21 +1409,21 @@
                                                                 </table>
                                                             </div>
                                                         </div>
-                                                        
-                                                       
-                                                        
+
+
+
                                                     </td>
-    
+
                                                     <td valign="top" align="right" style="width: 50%;">
                                                         <div *ngFor="let receive of ship.receivers;" style="    border: 1px dashed #8d8d8d;
                                                         padding: 10px;">
                                                             <b style="font-size: 12px;">RECEIVER:</b> <br>
                                                             <span class="text-capitalize">{{receive.companyName}}</span> <br>
                                                             {{receive.receiverAddress}}
-    
+
                                                             <div *ngFor="let drop of receive.dropPoint; let j = index;" class="pickup-item mt-2">
                                                                 <p class="m-0 text-dark"><b>Drop: {{j + 1}}</b> - {{drop.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}</p>
-                                                                
+
                                                                 <span *ngIf="drop.address.manual" style="width: 70%;display: inline-block;">
                                                                     {{ drop.address.address }}
                                                                     {{ drop.address.city }}
@@ -1436,7 +1435,7 @@
                                                                     {{ drop.address.dropOffLocation }}
                                                                 </span>
                                                                 <p class="m-0 text-dark">Contact Person: <b>{{drop.contactPerson}}</b></p>
-    
+
                                                                 <table width="100%" style="border-top: none;font-size: 12px;">
                                                                     <tbody>
                                                                         <tr>
@@ -1448,7 +1447,7 @@
                                                                                             <td style="width: 80px">DEL#</td>
                                                                                             <td style="width: 70px">QTY </td>
                                                                                             <td style="width: 70px">WEIGHT</td>
-                                                                                           
+
                                                                                         </tr>
                                                                                     </thead>
                                                                                     <tbody>
@@ -1457,10 +1456,10 @@
                                                                                             <td>{{commodity.del}}</td>
                                                                                             <td>{{commodity.quantity}} {{commodity.quantityUnit}}</td>
                                                                                             <td>{{commodity.weight}} {{commodity.weightUnit}}</td>
-                                                                                            
+
                                                                                         </tr>
-                                                                                        
-                            
+
+
                                                                                     </tbody>
                                                                                 </table>
                                                                             </td>
@@ -1469,14 +1468,14 @@
                                                                 </table>
                                                             </div>
                                                         </div>
-                                                        
+
                                                        <div *ngIf="invoiceData.data?.length > 1" class="html2pdf__page-break"></div>
                                                     </td>
                                                 </tr>
                                             </tbody>
-                                            
+
                                         </table>
-                                       
+
                                         <table class="invoice-iner__wrapper" *ngIf="invoiceData.data?.length - 1 === idx" width="100%" style="border-top: none;margin-top: 10px;">
                                             <tbody>
                                                 <tr>
@@ -1485,12 +1484,12 @@
                                                             <thead>
                                                                 <tr style="font-size: 12px;">
                                                                     <td colspan="6">FEE METHOD</td>
-                                                                   
+
                                                                     <td style="width: 100px" align="right">TOTAL</td>
                                                                 </tr>
                                                             </thead>
                                                             <tbody>
-                                                                
+
                                                                 <tr *ngIf="invoiceData.charges.freightFee.type != '' || invoiceData.charges.freightFee.type != null">
                                                                     <td colspan="8" style="padding: 0;">
                                                                         <table style="width: 100%;">
@@ -1498,7 +1497,7 @@
                                                                                 <tr class="item">
                                                                                     <td colspan="6">{{invoiceData.charges.freightFee.type}}
                                                                                         <small>(Freight Fees)</small></td>
-                                                                                    
+
                                                                                     <td align="right">
                                                                                         {{invoiceData.charges.freightFee.amount}}
                                                                                         <small>{{invoiceData.charges.freightFee.currency}}</small>
@@ -1516,18 +1515,18 @@
                                                                                     <td colspan="6">
                                                                                         {{invoiceData.charges.fuelSurcharge.type}}<small>
                                                                                             (Fuel Surcharge)</small></td>
-                                                                                    
+
                                                                                     <td align="right">
                                                                                         {{invoiceData.charges.fuelSurcharge.amount}}
                                                                                         <small>{{invoiceData.charges.fuelSurcharge.currency}}</small>
                                                                                     </td>
-                    
+
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>
                                                                     </td>
                                                                 </tr>
-                                                                
+
                                                                 <tr *ngIf="invoiceData.charges.accessorialFeeInfo.accessorialFee[0].type != ''">
                                                                     <td colspan="8" style="padding: 0;">
                                                                         <table style="width: 100%;">
@@ -1538,7 +1537,7 @@
                                                                                             Surcharge)</small></td>
                                                                                     <td align="right">{{item.amount}}
                                                                                         <small>{{item.currency}}</small></td>
-                    
+
                                                                                 </tr>
                                                                             </tbody>
                                                                         </table>
@@ -1554,14 +1553,14 @@
                                                                                         Deduction)</small></td>
                                                                                 <td align="right">- {{item.amount}}
                                                                                     <small>{{item.currency}}</small></td>
-                
+
                                                                             </tr>
                                                                             </tbody>
                                                                         </table>
                                                                     </td>
                                                                 </tr>
-                                                                
-                                                                
+
+
                                                                 <tr class="bg-transparent">
                                                                     <td align="right" colspan="6">Sub Total</td>
                                                                     <td align="right">{{invoiceData.subTotal}}
@@ -1572,7 +1571,7 @@
                                                                     <td align="right">{{invoiceData.taxesAmt}}
                                                                         <small>{{charges.freightFee.currency}} </small></td>
                                                                 </tr>
-                                                               
+
                                                             </tbody>
                                                             <tfoot class="border-1">
                                                                 <tr>
@@ -1595,10 +1594,10 @@
                                             </tbody>
                                         </table>
                                     </div>
-                                    
+
                                 </td>
                             </tr>
-                           
+
                         </tbody>
                     </table>
                 </section>

--- a/src/app/pages/dispatch/orders/order-detail/order-detail.component.ts
+++ b/src/app/pages/dispatch/orders/order-detail/order-detail.component.ts
@@ -9,6 +9,8 @@ import pdfMake from "pdfmake/build/pdfmake";
 import { ToastrService } from 'ngx-toastr';
 import { isObject } from 'util';
 import * as html2pdf from 'html2pdf.js';
+import { from } from 'rxjs';
+import { map } from 'rxjs/operators';
 declare var $: any;
 
 @Component({
@@ -154,6 +156,14 @@ export class OrderDetailComponent implements OnInit {
   today: any;
   cusAddressID: string;
   isInvoiced: boolean;
+  generateBtnDisabled = false;
+  errors = {};
+  response: any = '';
+  hasError = false;
+  hasSuccess = false;
+  Error = '';
+  Success = '';
+  invGenStatus = false;
   constructor(private apiService: ApiService,private accountService: AccountService, private domSanitizer: DomSanitizer, private route: ActivatedRoute, private toastr: ToastrService) {
     this.today = new Date();
    }
@@ -429,7 +439,8 @@ export class OrderDetailComponent implements OnInit {
 
   }
 
-  saveInvoice(){
+  saveInvoice() {
+    this.generateBtnDisabled = true;
     this.invoiceData[`transactionLog`] = [];
     this.invoiceData[`invNo`] = this.orderNumber;
     this.invoiceData[`invType`] = 'orderInvoice';
@@ -440,14 +451,48 @@ export class OrderDetailComponent implements OnInit {
     this.invoiceData[`balance`] = this.invoiceData.finalAmount;
     this.invoiceData[`txnDate`] = new Date().toISOString().slice(0, 10);
     this.invoiceData[`orderID`] = this.orderID;
-    this.accountService.postData(`order-invoice`, this.invoiceData).subscribe((res) => {
-      this.toastr.success('Invoice Added Successfully.');
+    // this.accountService.postData(`order-invoice`, this.invoiceData).subscribe((res) => {
+    //   if (res) {
+
+    //     $('#previewInvoiceModal').modal('hide');
+    //   }
+    //   this.toastr.success('Invoice Added Successfully.');
+    // });
+
+
+    this.accountService.postData(`order-invoice`, this.invoiceData).subscribe({
+      complete: () => { },
+      error: (err: any) => {
+        from(err.error)
+          .pipe(
+            map((val: any) => {
+              val.message = val.message.replace(/".*"/, 'This Field');
+              this.errors[val.context.key] = val.message;
+            })
+          )
+          .subscribe({
+            complete: () => {
+              this.generateBtnDisabled = false;
+              // this.throwErrors();
+            },
+            error: () => {
+              this.generateBtnDisabled = false;
+            },
+            next: () => {
+            },
+          });
+      },
+      next: (res) => {
+        $('#previewInvoiceModal').modal('hide');
+        this.generateBtnDisabled = false;
+        this.toastr.success('Invoice Added Successfully.');
+      },
     });
   }
 
   invoiceGenerated() {
-    const invStatus:boolean = true;
-    this.apiService.getData(`orders/invoiceStatus/${this.orderID}/${invStatus}`).subscribe((res) => {});
+    this.invGenStatus = true;
+    this.apiService.getData(`orders/invoiceStatus/${this.orderID}/${this.invGenStatus}`).subscribe((res) => {});
   }
 
   previewModal() {

--- a/src/app/pages/fleet/drivers/add-driver/add-driver.component.html
+++ b/src/app/pages/fleet/drivers/add-driver/add-driver.component.html
@@ -148,7 +148,7 @@
                             Username should be at-least 6 characters long and can be a combination of numbers, letters and dot(.).
 
                           </div>
-                        </div> 
+                        </div>
                       </div>
                       <div class="col-lg-5">
                         <label class="control-label font-weight-bold text-lg-right pt-2">Birth Date <span
@@ -235,17 +235,17 @@
                                     <div class="col-lg-12">
                                       <p class="text-dark pt-2 mb-0"> <span class="pr-1" [ngClass]="[passwordValidation.upperCase? 'green1': 'red1']">
                                           <i [ngClass]="[passwordValidation.upperCase? 'fas fa-check': 'fas fa-times']"> </i></span> atleast 1  uppercase</p>
-                                      
+
                                       <p class="text-dark pt-2 mb-0"> <span class="pr-1"
                                           [ngClass]="[passwordValidation.lowerCase ? 'green1': 'red1']"> <i
                                             [ngClass]="[passwordValidation.lowerCase ? 'fas fa-check': 'fas fa-times']"> </i></span> atleast 1 lowercase</p>
-                                        
+
                                     </div>
                                     <div class="col-lg-12">
                                       <p class="text-dark pt-2 mb-0"><span class="pr-1"
                                           [ngClass]="[passwordValidation.specialCharacters ? 'green1': 'red1']"> <i
                                             [ngClass]="[passwordValidation.specialCharacters ? 'fas fa-check': 'fas fa-times']"></i></span> atleast 1 special character(!@#$%^&*.-)</p>
-                                        
+
                                     </div>
                                   </div>
                                 </div>
@@ -320,7 +320,7 @@
                         </label>
                         <input [(ngModel)]="driverData.phone" name="phone" type="text" class="form-control"
                           (change)="onChangeHideErrors('phone')" placeholder="eg. 2234567891" #mob="ngModel"
-                          required pattern="[0-9]{1,10}$">
+                          required pattern="[0-9]{10}$">
                         <div *ngIf="mob.invalid && (mob.dirty || mob.touched)" class="text-danger">
                           <div *ngIf="mob.errors.required">
                             Phone is required.
@@ -537,7 +537,7 @@
                           <ng-select [(ngModel)]="item.addressType" name="address[{{i}}].addressType"
                             placeholder="Select address type">
                             <ng-option value="Home">Home</ng-option>
-                            <ng-option value="Maiing Address">Maiing Address</ng-option>
+                            <ng-option value="Mailing Address">Mailing Address</ng-option>
                           </ng-select>
                         </div>
                       </div>
@@ -654,7 +654,7 @@
                   <div class="col-lg-6">
                     <div class="row">
                       <div class="col-lg-10">
-                        <label class="control-label font-weight-bold text-lg-right pt-2">Document Type 
+                        <label class="control-label font-weight-bold text-lg-right pt-2">Document Type
                         </label>
                         <ng-select [(ngModel)]="document.documentType"
                           [attr.name]="'documentDetails['+i+'].documentType'" [ngModelOptions]="{standalone: true}"
@@ -678,7 +678,7 @@
                   <div class="col-lg-6">
                       <div class="row">
                         <div class="col-lg-5">
-                          <label class="control-label font-weight-bold text-lg-right pt-2">Document# 
+                          <label class="control-label font-weight-bold text-lg-right pt-2">Document#
                           </label>
                           <input [(ngModel)]="document.document" [attr.name]="'documentDetails['+i+'].document'"
                             [ngModelOptions]="{standalone: true}" type="text" class="form-control"
@@ -696,7 +696,7 @@
                           </div> -->
                         </div>
                         <div class="col-lg-5">
-                          <label class="control-label font-weight-bold text-lg-right pt-2">Issuing Authority 
+                          <label class="control-label font-weight-bold text-lg-right pt-2">Issuing Authority
                           </label>
                           <input [(ngModel)]="document.issuingAuthority"
                             [attr.name]="'documentDetails['+i+'].issuingAuthority'"
@@ -714,7 +714,7 @@
                   <div class="col-lg-6">
                     <div class="row">
                       <div class="col-lg-5">
-                        <label class="control-label font-weight-bold text-lg-right pt-2">Issuing Country 
+                        <label class="control-label font-weight-bold text-lg-right pt-2">Issuing Country
                         </label>
                         <ng-select
                           (change)="onChangeHideErrors('documentDetails['+i+'].issuingCountry');getDocStates($event,i)"
@@ -740,7 +740,7 @@
                   <div class="col-lg-6">
                     <div class="row">
                       <div class="col-5">
-                        <label class="control-label font-weight-bold text-lg-right pt-2">Issue Date 
+                        <label class="control-label font-weight-bold text-lg-right pt-2">Issue Date
                         </label>
                         <input [(ngModel)]="document.issueDate"
                           (click)="onChangeHideErrors('documentDetails['+i+'].issueDate');d.toggle()" ngbDatepicker
@@ -755,7 +755,7 @@
                         </div> -->
                       </div>
                       <div class="col-5" *ngIf="document.documentType != 'BCN'">
-                        <label class="control-label font-weight-bold text-lg-right pt-2"> Expiry Date 
+                        <label class="control-label font-weight-bold text-lg-right pt-2"> Expiry Date
                         </label>
                         <input [(ngModel)]="document.expiryDate" [attr.name]="'documentDetails['+i+'].expiryDate'"
                           [ngModelOptions]="{standalone: true}"
@@ -1062,7 +1062,7 @@
                             class="mandfield text-2 ml-1"><sup>*</sup></span></label>
                         <input (change)="onChangeHideErrors('SIN')"
                           [(ngModel)]="driverData.SIN" name="SIN"
-                          type="text" class="form-control" placeholder="9 digits , eg.123456789" #sin1="ngModel" required pattern="^[0-9]{9}$" 
+                          type="text" class="form-control" placeholder="9 digits , eg.123456789" #sin1="ngModel" required pattern="^[0-9]{9}$"
                            >
                         <div *ngIf="sin1.invalid && (sin1.dirty || sin1.touched)" class="text-danger">
                           <div *ngIf="sin1.errors.required">
@@ -1143,7 +1143,7 @@
                         <label class="control-label font-weight-bold text-lg-right pt-2">Waiting hour
                           start after</label>
                         <input [(ngModel)]="driverData.paymentDetails.waitingHourAfter"
-                          name="paymentDetails.waitingHourAfter" type="text" class="form-control" 
+                          name="paymentDetails.waitingHourAfter" type="text" class="form-control"
 
                           placeholder="eg. Min 3 hours">
                           <!-- <div *ngIf="payWait1.invalid && (payWait1.dirty || payWait1.touched)" class="text-danger">
@@ -1202,7 +1202,7 @@
                           <div class="col-lg-3">
                             <input [(ngModel)]="driverData.paymentDetails.loadPayPercentage"
                               name="paymentDetails.loadPayPercentage" type="text" class="form-control"
-                              placeholder="eg. 2%, 5%, 10%" 
+                              placeholder="eg. 2%, 5%, 10%"
 
                               (change)="onChangeHideErrors('paymentDetails.loadPayPercentage')">
                               <!-- <div *ngIf="lPay1.invalid && (lPay1.dirty || lPay1.touched)" class="text-danger">

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,8 +7,8 @@ export const environment = {
   isFeatureEnabled: true,
 
 
-  //BaseUrl: 'https://fleetservice.ap-south-1.fleethawks.com/api/v1/',
-  BaseUrl: 'http://localhost:3000/api/v1/',
+  BaseUrl: 'https://fleetservice.ap-south-1.fleethawks.com/api/v1/',
+ // BaseUrl: 'http://localhost:3000/api/v1/',
   AccountServiceUrl: 'http://localhost:4002/api/v1/',
   SafetyServiceUrl: 'http://localhost:4000/api/v1/',
 


### PR DESCRIPTION
## Change Description

search in invoice(manualm and order from invoice) and receipt
auto generated date in invoice and receipt
order detail page changes disabled generate button on click to avoid multiple entries of invoice

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: (Check only applicable)

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
