### PR TITLE
enhancement: driver payment and employee payment and other fixes

### DIFF
--- a/src/app/pages/accounts/invoices/add-invoice/add-invoice.component.html
+++ b/src/app/pages/accounts/invoices/add-invoice/add-invoice.component.html
@@ -436,7 +436,7 @@
                   </div>
                   <div class="form-group row mt-4">
                     <div class="col-lg-11 text-right">
-                      <a class="btn btn-default mr-2" (click)="cancelFn()">Cancel</a>
+                      <button class="btn btn-default mr-2" (click)="cancel()">Cancel</button>
                       <button class="btn btn-success mr-2" type="button" *ngIf="!invID" [disabled]="!invForm.form.valid || submitDisabled" (click)="addInvoice()">Save</button>
                       <button class="btn btn-success mr-2" type="button" *ngIf="invID" [disabled]="!invForm.form.valid || submitDisabled" (click)="updateInvoice()">Update</button>
                       <!-- <a href="#templateSelectionModal" class="modal-with-form btn btn-success">Save & Send</a> -->

--- a/src/app/pages/accounts/invoices/add-invoice/add-invoice.component.ts
+++ b/src/app/pages/accounts/invoices/add-invoice/add-invoice.component.ts
@@ -7,6 +7,7 @@ import * as moment from 'moment';
 import { from } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {Auth} from 'aws-amplify';
+import { Location } from '@angular/common';
 @Component({
   selector: 'app-add-invoice',
   templateUrl: './add-invoice.component.html',
@@ -20,6 +21,7 @@ export class AddInvoiceComponent implements OnInit {
     private apiService: ApiService,
     private toaster: ToastrService,
     private route: ActivatedRoute,
+    private location: Location,
     private router: Router) { }
     pageTitle = 'Add Invoice';
     dateMinLimit = { year: 2021, month: 1, day: 1 };
@@ -128,6 +130,9 @@ export class AddInvoiceComponent implements OnInit {
     this.accountService.getData(`chartAc/fetch/list`).subscribe((res: any) => {
       this.accounts = res;
     });
+  }
+  cancel() {
+    this.location.back(); // <-- go back to previous location on cancel
   }
   getCurrentuser = async () => {
     this.currentUser = (await Auth.currentSession()).getIdToken().payload;
@@ -327,13 +332,10 @@ export class AddInvoiceComponent implements OnInit {
         this.submitDisabled = false;
         this.response = res;
         this.toaster.success('Invoice Added Successfully.');
-        this.router.navigateByUrl('/accounts/invoices/list');
+        this.cancel();
       },
     });
   }
- cancelFn() {
-  this.router.navigateByUrl('/accounts/invoices/list');
- }
   async calculateAmount() {
     this.midAmt = 0;
     for (const element of this.invoiceData.details) {

--- a/src/app/pages/accounts/invoices/invoice-list/invoice-list.component.html
+++ b/src/app/pages/accounts/invoices/invoice-list/invoice-list.component.html
@@ -225,7 +225,7 @@
                         </td>
                       </tr>
                       <tr *ngFor="let inv of invoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -297,7 +297,7 @@
                         <td colspan="13">{{ dataMessage }}</td>
                       </tr>
                       <tr *ngFor="let inv of openOrderInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -351,7 +351,7 @@
                         </td>
                       </tr>
                       <tr *ngFor="let inv of openInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.txnDate | date : 'yyyy/MM/dd'}}
                         </td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -427,7 +427,7 @@
                         <td colspan="13">{{ dataMessage }}</td>
                       </tr>
                       <tr *ngFor="let inv of paidOrderInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -485,7 +485,7 @@
                         </td>
                       </tr>
                       <tr *ngFor="let inv of paidInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -553,7 +553,7 @@
                         <td colspan="13">{{ dataMessage }}</td>
                       </tr>
                       <tr *ngFor="let inv of partiallyPaidOrderInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -609,7 +609,7 @@
                         </td>
                       </tr>
                       <tr *ngFor="let inv of partiallyPaidInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -684,7 +684,7 @@
                         <td colspan="13">{{ dataMessage }}</td>
                       </tr>
                       <tr *ngFor="let inv of emailedOrderInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -741,7 +741,7 @@
                         </td>
                       </tr>
                       <tr *ngFor="let inv of emailedInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -811,7 +811,7 @@
                         <td colspan="13">{{ dataMessage }}</td>
                       </tr>
                       <tr *ngFor="let inv of voidedOrderInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
@@ -875,7 +875,7 @@
                         </td>
                       </tr>
                       <tr *ngFor="let inv of voidedInvoices; let i = index;">
-                        <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
+                        <td class="cursorpoint  font-weight-bold" (click)="routeFn(inv.invID, inv.invType)">{{inv.invNo}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">
                           {{inv.txnDate | date : 'yyyy/MM/dd'}}</td>
                         <td class="cursorpoint" (click)="routeFn(inv.invID, inv.invType)">

--- a/src/app/pages/accounts/payments/advance-payments/add-advance-payment/add-advance-payment.component.html
+++ b/src/app/pages/accounts/payments/advance-payments/add-advance-payment/add-advance-payment.component.html
@@ -265,7 +265,7 @@
                                     </div>
                                     <div class="form-group row mt-4">
                                         <div class="col-lg-10 text-right">
-                                            <a type="button" routerLink="/accounts/payments/advance-payments/list" class="btn btn-default mr-2">Cancel</a>
+                                            <button type="button" accounts class="btn btn-default mr-2" (click)="cancel()">Cancel</button>
                                             <button type="button" *ngIf="!paymentID" (click)="addRecord()" [disabled]="!payForm.form.valid || submitDisabled" class="btn btn-success">Save</button>
                                             <button type="button" *ngIf="paymentID && !paymentData.paymentLinked" (click)="updateRecord()" [disabled]="!payForm.form.valid || submitDisabled"  class="btn btn-success">Update</button>
                                         </div>

--- a/src/app/pages/accounts/payments/advance-payments/add-advance-payment/add-advance-payment.component.ts
+++ b/src/app/pages/accounts/payments/advance-payments/add-advance-payment/add-advance-payment.component.ts
@@ -5,7 +5,7 @@ import { ToastrService } from "ngx-toastr";
 import { from } from "rxjs";
 import { map } from "rxjs/operators";
 import { AccountService, ApiService, ListService } from "src/app/services";
-
+import { Location } from "@angular/common";
 @Component({
   selector: "app-add-advance-payment",
   templateUrl: "./add-advance-payment.component.html",
@@ -21,7 +21,7 @@ export class AddAdvancePaymentComponent implements OnInit {
     payMode: null,
     payModeNo: "",
     payModeDate: null,
-    txnDate: moment().format('YYYY-MM-DD'),
+    txnDate: moment().format("YYYY-MM-DD"),
     referenceNo: "",
     notes: "",
     accountID: null,
@@ -41,11 +41,11 @@ export class AddAdvancePaymentComponent implements OnInit {
   accounts = [];
   payModeLabel = "";
   errors = {};
-  response: any = '';
+  response: any = "";
   hasError = false;
   hasSuccess = false;
-  Error: string = '';
-  Success: string = '';
+  Error: string = "";
+  Success: string = "";
   submitDisabled = false;
   paymentID;
 
@@ -55,12 +55,13 @@ export class AddAdvancePaymentComponent implements OnInit {
     private router: Router,
     private toaster: ToastrService,
     private accountService: AccountService,
-    private apiService: ApiService
-  ) {}
+    private apiService: ApiService,
+    private location: Location
+  ) { }
 
   ngOnInit() {
-    this.paymentID = this.route.snapshot.params['paymentID'];
-    if(this.paymentID) {
+    this.paymentID = this.route.snapshot.params["paymentID"];
+    if (this.paymentID) {
       this.fetchPaymentDetails();
     }
     this.fetchDrivers();
@@ -68,7 +69,7 @@ export class AddAdvancePaymentComponent implements OnInit {
     this.fetchOwnerOperators();
     this.fetchEmployee();
     // this.fetchVendor();
-   // this.fetchCustomer();
+    // this.fetchCustomer();
     // this.listService.fetchChartAccounts();
     // this.accounts = this.listService.accountsList;
     this.fetchAccounts();
@@ -123,11 +124,13 @@ export class AddAdvancePaymentComponent implements OnInit {
         this.customers = result;
       });
   }
-
+  cancel() {
+    this.location.back(); // <-- go back to previous location on cancel
+  }
   addRecord() {
     this.submitDisabled = true;
     this.accountService.postData("advance", this.paymentData).subscribe({
-      complete: () => {},
+      complete: () => { },
       error: (err: any) => {
         from(err.error)
           .pipe(
@@ -144,14 +147,14 @@ export class AddAdvancePaymentComponent implements OnInit {
             error: () => {
               this.submitDisabled = false;
             },
-            next: () => {},
+            next: () => { },
           });
       },
       next: (res) => {
         this.submitDisabled = false;
         this.response = res;
         this.toaster.success("Advance payment added successfully.");
-        this.router.navigateByUrl("/accounts/payments/advance-payments/list");
+        this.cancel();
       },
     });
   }
@@ -177,7 +180,8 @@ export class AddAdvancePaymentComponent implements OnInit {
   }
 
   fetchPaymentDetails() {
-    this.accountService.getData(`advance/detail/${this.paymentID}`)
+    this.accountService
+      .getData(`advance/detail/${this.paymentID}`)
       .subscribe((result: any) => {
         this.paymentData = result[0];
         this.changePaymentMode(this.paymentData.payMode);
@@ -186,34 +190,36 @@ export class AddAdvancePaymentComponent implements OnInit {
 
   updateRecord() {
     this.submitDisabled = true;
-    this.accountService.putData(`advance/${this.paymentID}`, this.paymentData).subscribe({
-      complete: () => {},
-      error: (err: any) => {
-        from(err.error)
-          .pipe(
-            map((val: any) => {
-              val.message = val.message.replace(/".*"/, "This Field");
-              this.errors[val.context.key] = val.message;
-            })
-          )
-          .subscribe({
-            complete: () => {
-              this.submitDisabled = false;
-              // this.throwErrors();
-            },
-            error: () => {
-              this.submitDisabled = false;
-            },
-            next: () => {},
-          });
-      },
-      next: (res) => {
-        this.submitDisabled = false;
-        this.response = res;
-        this.toaster.success("Advance payment updated successfully.");
-        this.router.navigateByUrl("/accounts/payments/advance-payments/list");
-      },
-    });
+    this.accountService
+      .putData(`advance/${this.paymentID}`, this.paymentData)
+      .subscribe({
+        complete: () => { },
+        error: (err: any) => {
+          from(err.error)
+            .pipe(
+              map((val: any) => {
+                val.message = val.message.replace(/".*"/, "This Field");
+                this.errors[val.context.key] = val.message;
+              })
+            )
+            .subscribe({
+              complete: () => {
+                this.submitDisabled = false;
+                // this.throwErrors();
+              },
+              error: () => {
+                this.submitDisabled = false;
+              },
+              next: () => { },
+            });
+        },
+        next: (res) => {
+          this.submitDisabled = false;
+          this.response = res;
+          this.toaster.success("Advance payment updated successfully.");
+          this.cancel();
+        },
+      });
   }
 
   resetEntityVal() {

--- a/src/app/pages/accounts/payments/driver-payments/add-driver-payment/add-driver-payment.component.html
+++ b/src/app/pages/accounts/payments/driver-payments/add-driver-payment/add-driver-payment.component.html
@@ -418,9 +418,27 @@
                                                     </div>
                                                     <div class="col-lg-6">
                                                         <input type="text" class="form-control" [(ngModel)]="paymentData.taxes" name="taxes" (input)="paymentCalculation(); checkInput('tax')" disabled>
-                                                        <label class="error">{{ taxErr }}</label>
+                                                        <label class="error" *ngIf="taxErr">{{ taxErr }}</label>
                                                     </div>
                                                 </div>
+                                                <div class="row pt-1" *ngIf="paymentData.paymentTo === 'driver'">
+                                                  <div class="col-lg-6 text-right">
+                                                      <label class="control-label font-weight-bold">CPP</label>
+                                                  </div>
+                                                  <div class="col-lg-6">
+                                                      <input type="text" class="form-control" [(ngModel)]="paymentData.taxdata.cpp" name="taxdata.cpp" (input)="paymentCalculation(); checkInput('tax')" disabled>
+
+                                                  </div>
+                                              </div>
+                                              <div class="row pt-1" *ngIf="paymentData.paymentTo === 'driver'">
+                                                <div class="col-lg-6 text-right">
+                                                    <label class="control-label font-weight-bold">EI</label>
+                                                </div>
+                                                <div class="col-lg-6">
+                                                    <input type="text" class="form-control" [(ngModel)]="paymentData.taxdata.ei" name="taxdata.ei" (input)="paymentCalculation(); checkInput('tax')" disabled>
+
+                                                </div>
+                                            </div>
                                                 <div class="row pt-1">
                                                     <div class="col-lg-6 text-right">
                                                         <label class="control-label font-weight-bold">Advance</label>
@@ -446,7 +464,7 @@
                                         <div class="col-lg-11 text-right">
                                             <!-- <button type="button" class="btn btn-success modal-with-form mr-2" (click)="showCheque()">Cheque preview</button> -->
 
-                                            <button type="button" class="btn btn-default mr-2" routerLink="/accounts/payments/driver-payments/list">Cancel</button>
+                                            <button type="button" class="btn btn-default mr-2" (click)="cancel()">Cancel</button>
                                             <button type="button" class="btn btn-success modal-with-form" [disabled]="!paymentForm.form.valid || submitDisabled" *ngIf="!paymentID" (click)="addRecord()">Save</button>
                                         </div>
                                     </div>

--- a/src/app/pages/accounts/payments/driver-payments/add-driver-payment/add-driver-payment.component.ts
+++ b/src/app/pages/accounts/payments/driver-payments/add-driver-payment/add-driver-payment.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { HttpClient } from "@angular/common/http";
+import { HttpClient } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as moment from 'moment';
 import { ToastrService } from 'ngx-toastr';
@@ -8,6 +8,7 @@ import { map } from 'rxjs/operators';
 import Constants from 'src/app/pages/fleet/constants';
 import { AccountService, ApiService, ListService } from 'src/app/services';
 import { CountryStateCity } from 'src/app/shared/utilities/countryStateCities';
+import { Location } from '@angular/common';
 declare var $: any;
 
 @Component({
@@ -87,7 +88,8 @@ export class AddDriverPaymentComponent implements OnInit {
     private toaster: ToastrService,
     private accountService: AccountService,
     private apiService: ApiService,
-    private httpClient: HttpClient
+    private httpClient: HttpClient,
+    private location: Location,
   ) {}
 
   ngOnInit() {
@@ -297,10 +299,13 @@ export class AddDriverPaymentComponent implements OnInit {
     this.paymentData.advance = (this.paymentData.advance) ? Number(this.paymentData.advance) : 0;
     this.paymentData.taxes = (this.paymentData.taxes) ? Number(this.paymentData.taxes) : 0;
     this.paymentData.totalAmount = (this.paymentData.totalAmount) ? Number(this.paymentData.totalAmount) : 0;
-    this.paymentData.finalAmount = this.paymentData.totalAmount + this.paymentData.taxes - this.paymentData.advance;
-    this.paymentData.finalAmount = Number(this.paymentData.finalAmount);
+    this.paymentData.totalAmount = this.paymentData.totalAmount.toFixed(2);
+    this.paymentData.finalAmount = this.paymentData.totalAmount - this.paymentData.taxes - this.paymentData.taxdata.cpp - this.paymentData.taxdata.ei - this.paymentData.advance;
+    this.paymentData.finalAmount = Number(this.paymentData.finalAmount).toFixed(2);
   }
-
+  cancel() {
+    this.location.back(); // <-- go back to previous location on cancel
+  }
   addRecord() {
     if(this.paymentData.settlementIds.length === 0) {
       this.toaster.error("Please select settlement(s)");
@@ -547,7 +552,7 @@ export class AddDriverPaymentComponent implements OnInit {
           this.paymentData.taxdata.provincialTax = result.provncTax;
           this.paymentData.taxdata.emplCPP = result.employerCpp;
           this.paymentData.taxdata.emplEI = result.employerEI;
-          this.paymentData.taxes = this.paymentData.taxdata.cpp + this.paymentData.taxdata.ei + this.paymentData.taxdata.federalTax + this.paymentData.taxdata.provincialTax;
+          this.paymentData.taxes = this.paymentData.taxdata.federalTax + this.paymentData.taxdata.provincialTax;
           this.paymentData.taxes = Number(this.paymentData.taxes.toFixed(2));
 
           this.calculateFinalTotal();
@@ -583,7 +588,7 @@ export class AddDriverPaymentComponent implements OnInit {
       if(this.paymentData.taxdata.stateCode === v.stateCode) {
         this.provincalClaimCodes = v.codes;
       }
-    })
+    });
     this.paymentData.taxdata.provincialCode = 'claim_code_1';
     this.calculatePayroll();
   }
@@ -594,8 +599,8 @@ export class AddDriverPaymentComponent implements OnInit {
     this.paymentData.taxdata.federalTax = 0;
     this.paymentData.taxdata.provincialTax = 0;
     this.paymentData.taxdata.emplCPP = 0;
-      this.paymentData.taxdata.emplEI = 0;
-    this.paymentData.taxes = this.paymentData.taxdata.cpp + this.paymentData.taxdata.ei + this.paymentData.taxdata.federalTax + this.paymentData.taxdata.provincialTax;
+    this.paymentData.taxdata.emplEI = 0;
+    this.paymentData.taxes = this.paymentData.taxdata.federalTax + this.paymentData.taxdata.provincialTax;
     this.calculateFinalTotal();
   }
 }

--- a/src/app/pages/accounts/payments/driver-payments/driver-payments-detail/driver-payments-detail.component.html
+++ b/src/app/pages/accounts/payments/driver-payments/driver-payments-detail/driver-payments-detail.component.html
@@ -4,7 +4,7 @@
             <header class="page-header">
                 <div class="row pr-5 " style="padding-top:10px;">
                     <div class="col-md-4 col-lg-4 font-weight-bold text-4 text-dark">
-                        Carrier Payment# - 1279430
+                      {{ paymentData.paymentTo | titlecase }} Payment# - 1279430
                     </div>
                     <div class="col-md-8  col-lg-8 text-right pr-4">
                         <a routerLink="/accounts/payments/driver-payments/list" class="btn btn-sm btn-default"><i
@@ -33,10 +33,10 @@
                                                 <br>
                                                 <p class="mb-0 text-5 font-weight-bold text-dark">
                                                     <span *ngIf="paymentData.paymentTo == 'driver'">
-                                                        {{ drivers[paymentData.entityId] }}
+                                                        {{ drivers[paymentData.entityId] | titlecase}}
                                                     </span>
                                                     <span *ngIf="paymentData.paymentTo !== 'driver'">
-                                                        {{ contacts[paymentData.entityId] }}
+                                                        {{ contacts[paymentData.entityId] | titlecase}}
                                                     </span>
                                                 </p>
                                                 <p class="mb-0 text-uppercase">{{ paymentData.paymentTo }}</p>
@@ -62,10 +62,10 @@
                                                         <td width="40%" class="back-color-gray font-weight-bold">
                                                             Settlement(s)</td>
                                                         <td width="60%">
-                                                            <span *ngFor="let settl of paymentData.settlementIds; let s=index;">
+                                                            <!-- <span *ngFor="let settl of paymentData.settlementIds; let s=index;">
                                                                 {{ settlements[settl] }}
                                                                 <span *ngIf="s< paymentData.settlementIds.length-1">,</span>
-                                                            </span>
+                                                            </span> -->
                                                         </td>
                                                     </tr>
                                                     <tr>

--- a/src/app/pages/accounts/payments/driver-payments/driver-payments-list/driver-payments-list.component.html
+++ b/src/app/pages/accounts/payments/driver-payments/driver-payments-list/driver-payments-list.component.html
@@ -47,17 +47,6 @@
                      <button type="submit" class="btn btn-sm btn-success" (click)="resetFilter()">Reset</button>
                   </div>
                   <div class="col-md-3 col-lg-3 text-right pr-5">
-
-                     <div class="btn-group flex-wrap">
-                        <button type="button" class="btn btn-success btn-sm dropdown-toggle" data-toggle="dropdown"
-                           aria-expanded="false">Actions<span class="caret"></span></button>
-                        <div class="dropdown-menu" role="menu" x-placement="bottom-start"
-                           style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(0px, 38px, 0px);">
-
-                           <a class="dropdown-item text-1" href="">Import</a>
-                           <a class="dropdown-item text-1" href="">Export</a>
-                        </div>
-                     </div>
                      <a routerLink="/accounts/payments/driver-payments/add" class="btn btn-success btn-sm ml-2"
                         style="color:white;"><i class="fas fa-plus"></i> Add Payment </a>
 
@@ -68,10 +57,10 @@
          <div class="row">
             <div class="col pr-0">
                <section class="card">
-                  <div infiniteScroll 
-                     [infiniteScrollDistance]="1" 
-                     [infiniteScrollUpDistance]="1" 
-                     [infiniteScrollThrottle]="5" 
+                  <div infiniteScroll
+                     [infiniteScrollDistance]="1"
+                     [infiniteScrollUpDistance]="1"
+                     [infiniteScrollThrottle]="5"
                      (scrolled)="onScroll()">
                      <div class="card-body">
                         <table class="table table-bordered table-striped mb-0 simple-table">
@@ -104,7 +93,7 @@
                                     </span>
                                  </td>
                                  <td>
-                                    <strong class="text-capitalize">{{ data.paymentTo }}:</strong> 
+                                    <strong class="text-capitalize">{{ data.paymentTo }}:</strong>
                                     <span *ngIf="data.paymentTo === 'driver'">
                                        {{ drivers[data.entityId] }}
                                     </span>

--- a/src/app/pages/accounts/payments/employee-payment/add-employee-payment/add-employee-payment.component.html
+++ b/src/app/pages/accounts/payments/employee-payment/add-employee-payment/add-employee-payment.component.html
@@ -462,7 +462,7 @@
                                                         <input type="text" class="form-control" name="dedddd" [(ngModel)]="paymentData.deductionTotal" placeholder="e.g 150" disabled>
                                                     </div>
                                                     <div class="col-lg-6 offset-lg-6 pt-2"><a href="javascript:;" (click)="openPayrollModel()"
-                                                            class="btn btn-default modal-with-form btn-sm">Calculate
+                                                            class="btn btn-success font-weight-semibold modal-with-form btn-sm">Calculate
                                                             Payroll</a></div>
                                                 </div>
                                                 <div class="row pt-1">
@@ -471,9 +471,27 @@
                                                     </div>
                                                     <div class="col-lg-6">
                                                         <input type="text" class="form-control" name="taxes" [(ngModel)]="paymentData.taxes" placeholder="e.g 150" (input)="calculateFinalTotal(); checkInput('tax')" disabled>
-                                                        <label class="error">{{ taxErr }}</label>
+                                                        <label class="error" *ngIf="taxErr">{{ taxErr }}</label>
                                                     </div>
                                                 </div>
+                                                <div class="row pt-1">
+                                                  <div class="col-lg-6 text-right"><label
+                                                          class="control-label font-weight-bold">CPP</label>
+                                                  </div>
+                                                  <div class="col-lg-6">
+                                                      <input type="text" class="form-control" name="taxdata.cpp" [(ngModel)]="paymentData.taxdata.cpp" placeholder="e.g 150" (input)="calculateFinalTotal()" disabled>
+
+                                                  </div>
+                                              </div>
+                                              <div class="row pt-1">
+                                                <div class="col-lg-6 text-right"><label
+                                                        class="control-label font-weight-bold">EI</label>
+                                                </div>
+                                                <div class="col-lg-6">
+                                                    <input type="text" class="form-control" name="taxdata.ei" [(ngModel)]="paymentData.taxdata.ei" placeholder="e.g 150" (input)="calculateFinalTotal()" disabled>
+
+                                                </div>
+                                            </div>
                                                 <div class="row pt-1">
                                                     <div class="col-lg-6 text-right"><label
                                                             class="control-label font-weight-bold">Advance</label>
@@ -497,7 +515,7 @@
 
                                     <div class="form-group row mt-4">
                                         <div class="col-lg-11 text-right">
-                                            <button type="button" class="btn btn-default mr-2" routerLink="">Cancel</button>
+                                            <button type="button" class="btn btn-default mr-2" (click)="cancel()">Cancel</button>
                                             <button class="btn btn-success" (click)="addRecord()" [disabled]="!empPaymentForm.form.valid || submitDisabled" *ngIf="!paymentID">Save</button>
                                         </div>
                                     </div>

--- a/src/app/pages/accounts/payments/employee-payment/employee-payment-detail/employee-payment-detail.component.html
+++ b/src/app/pages/accounts/payments/employee-payment/employee-payment-detail/employee-payment-detail.component.html
@@ -32,7 +32,7 @@
                                  <div class="text-center p-4 cerbor">
                                     <i class="fa fa-user text-7"></i>
                                     <br>
-                                    <p class="mb-0 text-5 font-weight-bold text-dark">{{ empdetail.firstName }} {{ empdetail.lastName }}</p>
+                                    <p class="mb-0 text-5 font-weight-bold text-dark">{{ empdetail.firstName | titlecase}} {{ empdetail.lastName | titlecase }}</p>
                                     <p class="mb-0">EMPLOYEE NAME</p>
                                  </div>
                               </div>

--- a/src/app/pages/accounts/settlements/add-settlement/add-settlement.component.html
+++ b/src/app/pages/accounts/settlements/add-settlement/add-settlement.component.html
@@ -183,7 +183,7 @@
                                                         <tr *ngFor="let trp of settledTrips; let t=index;">
                                                             <td *ngIf="!settlementData.paymentLinked">
                                                                 <span *ngIf="settledTrips.length > 1">
-                                                                    <a href="javascript:;" (click)="remStldTrip(trp.tripID, t)"> 
+                                                                    <a href="javascript:;" (click)="remStldTrip(trp.tripID, t)">
                                                                         <i class="fa fa-trash"></i>
                                                                     </a>
                                                                 </span>
@@ -193,7 +193,7 @@
                                                                         <i class="fa fa-trash" style="color: #CCC"></i>
                                                                     <!-- </a> -->
                                                                 </span>
-                                                                
+
                                                             </td>
                                                             <td>{{ trp.tripNo }}</td>
                                                             <td>{{ trp.dateCreated | date:"yyyy/MM/dd" }}</td>
@@ -829,7 +829,7 @@
 
                                     <div class="form-group row mt-4">
                                         <div class="col-lg-11 text-right">
-                                            <button class="btn btn-default mr-2" routerLink="/accounts/settlements/list">Cancel</button>
+                                            <button type="button" class="btn btn-default mr-2" (click)="cancel()">Cancel</button>
                                             <button class="btn btn-success" *ngIf="!settlementID" [disabled]="!settlementForm.form.valid || submitDisabled" (click)="addRecord()">Save</button>
                                             <button class="btn btn-success" *ngIf="settlementID && !settlementData.paymentLinked" [disabled]="!settlementForm.form.valid || submitDisabled" (click)="updateRecord()">Update</button>
                                         </div>

--- a/src/app/pages/dispatch/orders/add-orders/add-orders.component.html
+++ b/src/app/pages/dispatch/orders/add-orders/add-orders.component.html
@@ -192,9 +192,9 @@
                                     </div>
                                     <div class="row pl-3 pr-3">
                                        <div class="col-lg-12 pr-0" >
-                                          
 
-                                          <div style="max-height: 200px;overflow-y: auto; overflow-x: hidden;" 
+
+                                          <div style="max-height: 200px;overflow-y: auto; overflow-x: hidden;"
                                              *ngFor="let item of customerSelected">
                                              <div class="row">
                                                 <div class="col-lg-6">
@@ -206,7 +206,7 @@
                                                       {{item.workPhone ? item.workPhone : '-'}}</label>
                                                 </div>
                                              </div>
-                                            
+
                                              <div class="row border-top mb-1 pt-2 pb-2 position-relative" [ngClass]="{'pl-4' : item.address.length > 1}" *ngFor="let address of item.address; let i = index;">
                                                 <div class="col-12">
                                                    <label class="control-label" *ngIf="address.manual"><span class=" font-weight-bold">Address:</span>
@@ -216,8 +216,8 @@
                                                    <label class="control-label" *ngIf="!address.manual"><span class=" font-weight-bold">Address:</span>
                                                       {{address.userLocation}}</label>
                                                 </div>
-                                                
-                                               
+
+
                                                 <div class="col-6">
                                                    <label class="control-label"><span class=" font-weight-bold">City:</span>
                                                       {{address.cityName}}</label>
@@ -234,12 +234,12 @@
                                                    <label class="control-label"><span class=" font-weight-bold">Type:</span>
                                                       {{address.addressType}}</label>
                                                 </div>
-                                                
+
                                                 <input *ngIf="item.address.length > 1" class="address-icon" type="radio" name="select" (change)="getAddressID($event.target.checked, i, address.addressID)" [value]="address.addressID" [checked]="address.isChecked">
-                                                
-                                                
+
+
                                              </div>
-                                             
+
 
                                           </div>
 
@@ -260,7 +260,7 @@
                                  <input placeholder="eg. 024933435"[(ngModel)]="orderData.cusConfirmation" name="cusConfirmation" type="text" class="form-control" >
 
                               </div>
-                              
+
                            </div>
                            <div class="row mt-2">
                               <div class="col-lg-6">
@@ -334,7 +334,7 @@
                                                                            <td class="border-top-0 border-bottom border-left-0 border-right-0">
                                                                               {{point.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}
                                                                            </td>
-                                                                           
+
                                                                         </tr>
                                                                      </table>
                                                                   </td>
@@ -346,9 +346,9 @@
                                                             </tbody>
                                                          </table>
                                                       </td>
-                                                      
-                                                      
-                                                      
+
+
+
                                                    </tr>
 
                                                 </tbody>
@@ -378,7 +378,7 @@
                                                                            <td class="border-top-0 border-bottom border-left-0 border-right-0">
                                                                               {{point.dateAndTime | date:'yyyy/MM/dd hh:mm a'}}
                                                                            </td>
-                                                                           
+
                                                                         </tr>
                                                                      </table>
                                                                   </td>
@@ -391,7 +391,7 @@
                                                          </table>
                                                       </td>
                                                    </tr>
-                                                  
+
 
                                                 </tbody>
                                              </table>
@@ -434,7 +434,7 @@
                                                             <div *ngIf="conSlt1.touched && (shippersReceivers[0].shippers.shipperID == null || shippersReceivers[0].shippers.shipperID == '') && finalShippersReceivers[0].shippers.length == 0" class="text-danger">
                                                                Shipper is required.
                                                            </div>
-                                                           
+
                                                          </div>
                                                          <div class="col-2 mar-top-37  p-0">
                                                             <a data-toggle="modal" (click)="setValue()" data-target="#addShipperModal" href="javascript:;"
@@ -445,10 +445,10 @@
                                                            class="modal-with-form btn btn-sm btn-success ml-2">
                                                                <em class="fas fa-sync"></em>
                                                             </a>
-                                                           
+
                                                          </div>
                                                       </div>
-                                                      
+
                                                       <div class="addsr-scrollbar addsr-scroll-y pickup-location__main">
                                                          <div *ngFor="let pick of item.shippers.pickupPoint; let w = index;" [ngClass]="{'p-3 bg-grey mt-2': w != 0}">
                                                             <div class="row mt-3" [ngClass]="{'mr-4': w == 0}">
@@ -461,34 +461,34 @@
                                                                   name="pickupLocation_{{i}}{{w}}" class="form-control " #pickupLocation="ngModel" required
                                                                   pickupLocation tabindex="-1" aria-hidden="true" autocomplete="off"
                                                                   #location="ngModel" required>
-   
+
                                                                      <ng-option *ngFor="let item of shipAddresses" value="{{item.addressID}}">
                                                                         <span *ngIf="!item.manual">
                                                                            {{item.userLocation}}
                                                                         </span>
                                                                         <span *ngIf="item.manual">
-                                                                           {{item.address1}}<span *ngIf="item.address1">,</span> 
-                                                                           {{item.address2}}<span *ngIf="item.address2">,</span> 
-                                                                           {{item.cityName}}<span *ngIf="item.cityName">,</span> 
-                                                                           {{item.stateName}}<span *ngIf="item.cityName">,</span> 
+                                                                           {{item.address1}}<span *ngIf="item.address1">,</span>
+                                                                           {{item.address2}}<span *ngIf="item.address2">,</span>
+                                                                           {{item.cityName}}<span *ngIf="item.cityName">,</span>
+                                                                           {{item.stateName}}<span *ngIf="item.cityName">,</span>
                                                                            {{item.countryName}}
                                                                            {{item.zipCode}}
                                                                         </span>
                                                                      </ng-option>
-                                                                     
+
                                                                </ng-select>
                                                                   <!-- <input placeholder="eg. Calgary,Alberta" [disabled]="pick.address.manual" [(ngModel)]="pick.address.pickupLocation"
                                                                      name="pickupLocation_{{i}}{{w}}" (keyup)="searchTerm.next($event);"
                                                                      class="form-control " #pickupLocation="ngModel" required
                                                                      pickupLocation tabindex="-1" aria-hidden="true" autocomplete="off"
                                                                      #location="ngModel" required> -->
-      
+
                                                                      <!-- <div *ngIf="pickupLocation.touched && shippersReceivers[0].shippers.pickupLocation == '' && finalShippersReceivers[0].shippers.length == 0" class="text-danger">
-      
+
                                                                          Pickup location is required.
-      
+
                                                                      </div> -->
-                                                                     
+
                                                                   <!-- <div class="map-search__results bg-white row mt-3 mar-top-30 ml-0" style="width: 93%" *ngIf=searchResults>
                                                                      <ul class="p-0 m-0 text-left w-100">
                                                                         <li *ngFor="let item of searchResults;">
@@ -527,7 +527,7 @@
                                                                   <input [(ngModel)]="pick.unitNumber"
                                                                   name="unitNumber_{{i}}{{w}}" type="text" class="form-control" placeholder="Unit Number">
                                                                </div>
-                                                            
+
                                                             </div>
                                                             <div class="row mt-3 mr-4" *ngIf="pick.address.manual">
                                                                <div class="col-lg-12">
@@ -553,7 +553,7 @@
                                                                   >
                                                                 </ng-select>
                                                                </div>
-                                                               
+
                                                                <div class="col-lg-6 pull-left">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark">Province/State <span class="mandfield text-2 ml-1"><sup>*</sup></span></label>
                                                                   <!-- <input [(ngModel)]="pick.address.state"
@@ -601,9 +601,9 @@
                                                                      </div>
                                                                   </div>
                                                                </div>
-                                                            
+
                                                             </div>
-                                                            
+
                                                             <div class="row mt-3 mr-4">
                                                                <div class="col-lg-12 col-md-12">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
@@ -611,22 +611,22 @@
                                                                   </label>
                                                                </div>
                                                                <div class="col-lg-6">
-      
-      
+
+
                                                                   <div class="input-group">
-      
+
                                                                         <input [(ngModel)]="pick.pickupDate" name="pickupDate_{{i}}{{w}}" type="text"
                                                                         placeholder="yyyy/mm/dd" (click)="pickupDate.toggle()" ngbDatepicker #pickupDate="ngbDatepicker"
                                                                         class="form-control" autocomplete="off" #orderDate1="ngModel" required [minDate]="dateMinLimit" [maxDate]="futureDatesLimit">
-      
-      
+
+
                                                                   </div>
                                                                   <!-- <div *ngIf="orderDate1.touched && (shippersReceivers[0].shippers.pickupDate == null || shippersReceivers[0].shippers.pickupDate == '') && finalShippersReceivers[0].shippers.length == 0" class="text-danger">
-      
+
                                                                       Pickup date required.
-      
+
                                                                  </div> -->
-      
+
                                                                </div>
                                                                <div class="col-lg-6">
                                                                   <div class="input-group">
@@ -638,39 +638,39 @@
                                                                      name="item.pickupTime{{i}}" type="text" class="form-control" placeholder="hour:minute"  #pickupTime="ngModel" required pickupTime id="timepicker2"> -->
                                                                   </div>
                                                                   <!-- <div *ngIf="pickupTime.touched && (shippersReceivers[0].shippers.pickupTime == null || shippersReceivers[0].shippers.pickupTime == '') && finalShippersReceivers[0].shippers.length == 0" class="text-danger">
-      
+
                                                                      Pickup time is required.
-      
+
                                                                 </div> -->
                                                                </div>
                                                                <!-- <div class="col-lg-3 mt-1">
                                                                </div> -->
                                                             </div>
-                                                            
+
                                                             <div class="row mt-3 mr-4">
-      
+
                                                                <div class="col-lg-6 col-md-6">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                      for="inputDefault">Contact Person at Pickup
                                                                      <!-- <span class="mandfield text-2 ml-1"><sup>*</sup></span> -->
                                                                   </label>
-      
+
                                                                   <input placeholder="eg. John Smith" [(ngModel)]="pick.contactPerson"
                                                                      name="shippers.contactPerson_{{i}}{{w}}" type="text" class="form-control"
                                                                      id="inputDefault" >
-      
+
                                                                </div>
                                                                <div class="col-lg-6 col-md-6">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                      for="inputDefault">Phone
                                                                      <!-- <span class="mandfield text-2 ml-1"><sup>*</sup></span> -->
                                                                   </label>
-      
+
                                                                   <input placeholder="eg. 2234567891" [(ngModel)]="pick.phone" name="shippers.phone_{{i}}{{w}}"
                                                                      type="text" class="form-control" id="inputDefault" >
-      
+
                                                                </div>
-      
+
                                                             </div>
                                                             <div class="row mt-3 mr-4">
 
@@ -680,39 +680,39 @@
                                                                   </label>
                                                                   <ng-select multiple="true" notFoundText="Please type to add numbers" [addTag]="true" placeholder="eg. 0006,123" [(ngModel)]="pick.customerPO" name="customerPO_{{i}}{{w}}" type="text"
                                                                      class="form-control h-auto"></ng-select>
-                                 
+
                                                                </div>
                                                             </div>
                                                             <div *ngFor="let commodity of pick.commodity; let z = index;">
                                                                <div class="row mt-3 mr-4 align-items-center">
-                                                                  
+
                                                                   <div class="col-lg-6">
                                                                      <label class="control-label font-weight-bold labelmt text-3 text-dark">Commodity <span class="mandfield text-2 ml-1"><sup>*</sup></span>
                                                                         <!-- <span class="mandfield text-2 ml-1"><sup>*</sup></span> -->
                                                                      </label>
                                                                      <input placeholder="eg. cakes" type="text" [(ngModel)]="commodity.name" name="name_{{i}}{{w}}{{z}}" class="form-control" >
-      
+
                                                                   </div>
                                                                   <div class="col-lg-5">
                                                                      <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                         >PU# &nbsp;<i class="fas fa-question-circle" data-toggle="tooltip"
                                                                         data-placement="top"
                                                                         title="Pickup Number"></i> <span class="mandfield text-2 ml-1"><sup>*</sup></span>
-      
+
                                                                      </label>
-      
+
                                                                      <input placeholder="eg. 1348,0096" [(ngModel)]="commodity.pu"
                                                                         name="pu{{i}}{{w}}{{z}}" type="text" class="form-control" >
-      
+
                                                                   </div>
                                                                   <div class="col-lg-1 text-right mt-4 pl-0">
                                                                      <a class="btn btn-success btn-sm mt-2" href="javascript:;" *ngIf="z != 0" (click)="removeCommodity('shipper', i, w, z)"><i class="fas fa-minus"></i> </a>
                                                                      <a class="btn btn-success btn-sm btn btn-success btn-sm mt-2" href="javascript:;" *ngIf="z == 0" (click)="addCommodity('shipper', i, w)"><i class="fas fa-plus"></i></a>
                                                                   </div>
                                                                </div>
-                                                               
-                                                
-      
+
+
+
                                                                <div class="row mt-3 mr-4">
                                                                   <div class="col-6">
                                                                      <div class="col-lg-12 p-0">
@@ -722,14 +722,14 @@
                                                                      </div>
                                                                      <div class="row">
                                                                         <div class="col-lg-6">
-      
+
                                                                            <input placeholder="eg. 20,400" type="text" [(ngModel)]="commodity.quantity" name="quantity_{{i}}{{w}}{{z}}" class="form-control" >
-            
+
                                                                         </div>
-            
-            
+
+
                                                                         <div class="col-lg-6">
-            
+
                                                                            <ng-select dropdownPosition='top' [(ngModel)]="commodity.quantityUnit" name="quantityUnit_{{i}}{{w}}{{z}}" placeholder="eg. select quantity"class="form-control">
                                                                                  <ng-option value="Bag" data-select2-id="21">Bag</ng-option>
                                                                                  <ng-option value="Bale" data-select2-id="285">Bale</ng-option>
@@ -743,21 +743,21 @@
                                                                                  <ng-option value="Cases" data-select2-id="293">Cases</ng-option>
                                                                                  <ng-option value="Pallets" data-select2-id="294">Pallets</ng-option>
                                                                            </ng-select>
-            
-            
+
+
                                                                         </div>
                                                                      </div>
                                                                   </div>
                                                                   <div class="col-6">
                                                                      <div class="col-lg-12 p-0">
                                                                         <label class="control-label font-weight-bold labelmt text-3 text-dark">Weight
-                                                                           <span class="mandfield text-2 ml-1"><sup>*</sup></span>                                                                     
+                                                                           <span class="mandfield text-2 ml-1"><sup>*</sup></span>
                                                                         </label>
                                                                      </div>
                                                                      <div class="row">
-                                                                  
+
                                                                         <div class="col-lg-6">
-            
+
                                                                            <input placeholder="eg. 500 Kg" type="text" [(ngModel)]="commodity.weight" name="weight_{{i}}{{w}}{{z}}" class="form-control" >
                                                                            <!-- <div *ngIf="oWeight.invalid && (oWeight.dirty || oWeight.touched)" class="text-danger">
                                                                               <div *ngIf="oWeight.errors.pattern">
@@ -770,38 +770,38 @@
                                                                               This Field is required
                                                                            </span> -->
                                                                         </div>
-            
+
                                                                         <div class="col-lg-6">
                                                                            <ng-select dropdownPosition='top' placeholder="eg. select weight" [(ngModel)]="commodity.weightUnit" name="weightUnit_{{i}}{{w}}{{z}}" class="form-control" data-select2-id="19" tabindex="-1" aria-hidden="false" >
-            
+
                                                                                  <ng-option value="ton(s)">ton(s)</ng-option>
                                                                                  <ng-option value="kg">Kilograms</ng-option>
                                                                                  <ng-option value="lbs">lbs</ng-option>
                                                                            </ng-select>
-            
-            
+
+
                                                                         </div>
-            
+
                                                                      </div>
                                                                   </div>
-                                                                  
+
                                                                </div>
-                                                              
+
                                                             </div>
                                                             <div class="row mt-3 mr-4">
-      
+
                                                                <div class="col-lg-12 col-md-12">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                      for="inputDefault">Pickup Instruction</label>
-      
+
                                                                   <textarea placeholder="eg. Enter pickup instruction" [(ngModel)]="pick.pickupInstruction"
                                                                      name="pickupInstruction_{{i}}{{w}}" class="form-control h-auto" rows="2" #Pickup1= "ngModel" pattern ="^[\s\S]{500}$"
                                                                      ></textarea>
-      
+
                                                                </div>
-      
+
                                                             </div>
-                                                            
+
                                                          </div>
                                                       </div>
                                                       <div class="row mt-3 mr-4">
@@ -833,7 +833,7 @@
                                                                   <label class="control-label mt-2 font-weight-bold pl-3"></label>
                                                                </div>
                                                          </div>
-                                                         
+
                                                          <div class="col-12 text-right mt-3">
                                                             <a *ngIf="item.shippers.save" href="javascript:;" (click)="saveShipper(i)"
                                                                class="btn btnw90px btn-md btn-dark">Save</a>
@@ -893,7 +893,7 @@
                                                          </div>
                                                       </div>
                                                       <div class="addsr-scrollbar addsr-scroll-y pickup-location__main">
-                                                         
+
                                                          <div *ngFor="let dropItem of item.receivers.dropPoint; let y = index;" class="mr-4" [ngClass]="{'p-3 bg-grey mt-2': y != 0}">
                                                             <div class="row mt-3">
 
@@ -906,21 +906,21 @@
                                                                   name="dropOffLocation_{{i}}{{y}}" #dropLoc="ngModel"
                                                                   required dropLoc class="form-control" autocomplete="off"
                                                                   tabindex="-1" aria-hidden="true" #drop="ngModel" required >
-   
+
                                                                      <ng-option *ngFor="let item of receiverAddresses" value="{{item.addressID}}">
                                                                         <span *ngIf="!item.manual">
                                                                            {{item.userLocation}}
                                                                         </span>
                                                                         <span *ngIf="item.manual">
-                                                                           {{item.address1}} <span *ngIf="item.address1">,</span> 
-                                                                           {{item.address2}} <span *ngIf="item.address2">,</span> 
-                                                                           {{item.cityName}} <span *ngIf="item.cityName">,</span> 
-                                                                           {{item.stateName}} <span *ngIf="item.cityName">,</span> 
+                                                                           {{item.address1}} <span *ngIf="item.address1">,</span>
+                                                                           {{item.address2}} <span *ngIf="item.address2">,</span>
+                                                                           {{item.cityName}} <span *ngIf="item.cityName">,</span>
+                                                                           {{item.stateName}} <span *ngIf="item.cityName">,</span>
                                                                            {{item.countryName}}
                                                                            {{item.zipCode}}
                                                                         </span>
                                                                      </ng-option>
-   
+
                                                                </ng-select>
                                                                   <!-- <input placeholder="eg. Calgary,Alberta" [disabled]="dropItem.address.manual" [(ngModel)]="dropItem.address.dropOffLocation"
                                                                      name="dropOffLocation_{{i}}{{y}}" #dropLoc="ngModel"
@@ -930,10 +930,10 @@
                                                                      tabindex="-1" aria-hidden="true" #drop="ngModel" required > -->
                                                                      <!-- <div *ngIf="dropOffLocation.touched && shippersReceivers[0].receivers.dropOffLocation == '' && finalShippersReceivers[0].receivers.length == 0" class="text-danger">
                                                                          Drop off location is required.
-      
-      
+
+
                                                                     </div> -->
-      
+
                                                                   <!-- <div class="map-search__results bg-white row mt-3 mar-top-30 ml-0" style="width: 93%">
                                                                      <ul class="p-0 m-0 text-left w-100">
                                                                         <li *ngFor="let item of searchResults;">
@@ -972,7 +972,7 @@
                                                                   <input [(ngModel)]="dropItem.unitNumber"
                                                                   name="unitNumber_{{i}}{{y}}" type="text" class="form-control" placeholder="Unit Number">
                                                                </div>
-                                                            
+
                                                                <div class="col-12 pl-4 pr-4">
                                                                   <div class="row">
                                                                      <div class="col-12 bordbtm">
@@ -980,7 +980,7 @@
                                                                      </div>
                                                                   </div>
                                                                </div>
-                                                            
+
                                                             </div>
                                                             <div class="row mt-3" *ngIf="dropItem.address.manual">
                                                                <div class="col-lg-12">
@@ -990,7 +990,7 @@
                                                                </div>
                                                                <div class="col-lg-6 pull-left">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark">Country <span class="mandfield text-2 ml-1"><sup>*</sup></span></label>
-                                                                 
+
                                                                   <ng-select
                                                                   (change)="getStates($event, 'receiver', i, y)"
                                                                   [(ngModel)]="dropItem.address.countryCode"
@@ -1005,10 +1005,10 @@
                                                                   >
                                                                 </ng-select>
                                                                </div>
-                                                               
+
                                                                <div class="col-lg-6 pull-left">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark">Province/State <span class="mandfield text-2 ml-1"><sup>*</sup></span></label>
-                                                                 
+
                                                                   <ng-select
                                                                      (change)="getCities($event, 'receiver', i, y)"
                                                                      [(ngModel)]="dropItem.address.stateCode"
@@ -1025,7 +1025,7 @@
                                                                </div>
                                                                <div class="col-lg-6 pull-left">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark">City <span class="mandfield text-2 ml-1"><sup>*</sup></span></label>
-                                                                 
+
                                                                   <ng-select
                                                                      [(ngModel)]="dropItem.address.cityName"
                                                                      name="cityID_{{i}}{{y}}"
@@ -1051,7 +1051,7 @@
                                                                      </div>
                                                                   </div>
                                                                </div>
-                                                            
+
                                                             </div>
                                                             <div class="row mt-3">
                                                                <div class="col-lg-12">
@@ -1062,20 +1062,20 @@
                                                                </div>
                                                                <div class="col-lg-6">
                                                                   <div class="input-group">
-      
+
                                                                      <input [(ngModel)]="dropItem.dropOffDate" name="dropOffDate_{{i}}{{y}}" type="text"
                                                                         placeholder="yyyy/mm/dd" (click)="dropOffDate.toggle()" ngbDatepicker #dropOffDate="ngbDatepicker"
                                                                         class="form-control" autocomplete="off" #delDate="ngModel" required  [minDate]="dateMinLimit" [maxDate]="futureDatesLimit">
-      
-      
+
+
                                                                   </div>
                                                                   <!-- <div *ngIf="delDate.touched && shippersReceivers[0].receivers.dropOffDate == '' && finalShippersReceivers[0].receivers.length == 0" class="text-danger">
-      
-      
+
+
                                                                     Delivery date is required.
-      
+
                                                                  </div> -->
-      
+
                                                                </div>
                                                                <div class="col-lg-6">
                                                                   <div class="input-group">
@@ -1085,23 +1085,23 @@
                                                                         />
                                                                   </div>
                                                                   <!-- <div *ngIf="dropOffTime.touched && shippersReceivers[0].receivers.dropOffTime == '' && finalShippersReceivers[0].receivers.length == 0" class="text-danger">
-      
-      
+
+
                                                                      Delivery time is required.
-      
+
                                                                   </div> -->
                                                                </div>
                                                                <!-- <div class="col-lg-3 mt-1">
                                                                </div> -->
                                                             </div>
                                                             <div class="row mt-3">
-      
+
                                                                <div class="col-6">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                      for="inputDefault">Contact Person at Delivery
                                                                      <!-- <span class="mandfield text-2 ml-1"><sup>*</sup></span>                                                                      -->
                                                                   </label>
-      
+
                                                                   <input placeholder="eg. John Smith" [(ngModel)]="dropItem.contactPerson"
                                                                      name="contactPerson_{{i}}{{y}}" type="text" class="form-control"
                                                                      id="inputDefault" >
@@ -1115,13 +1115,13 @@
                                                                      This Field is required
                                                                   </span> -->
                                                                </div>
-                                                               
+
                                                                <div class="col-6">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                      for="inputDefault">Phone
                                                                      <!-- <span class="mandfield text-2 ml-1"><sup>*</sup></span>                                                                      -->
                                                                   </label>
-      
+
                                                                   <input placeholder="eg. 2234567891" [(ngModel)]="dropItem.phone" name="phone_{{i}}{{y}}"
                                                                      type="text" class="form-control" id="inputDefault" >
                                                                      <!-- <div *ngIf="cPhone.invalid && (cPhone.dirty || cPhone.touched)" class="text-danger">
@@ -1135,7 +1135,7 @@
                                                                   </span> -->
                                                                </div>
                                                             </div>
-      
+
                                                             <div *ngFor="let commodity of dropItem.commodity; let z = index;">
                                                                <div class="row mt-3">
                                                                   <div class="col-6">
@@ -1146,27 +1146,27 @@
                                                                      </div>
                                                                      <div class="row">
                                                                         <div class="col-12">
-         
+
                                                                            <input placeholder="eg. cakes" type="text" [(ngModel)]="commodity.name" name="name{{i}}{{y}}{{z}}" class="form-control" >
-            
-            
+
+
                                                                         </div>
-                                                                        
+
                                                                      </div>
                                                                   </div>
-                                                                  
+
                                                                   <div class="col-5">
                                                                      <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                         >DEL# &nbsp;<i
                                                                         class="fas fa-question-circle" data-toggle="tooltip"
                                                                         data-placement="top"
                                                                         title="Delivery Number "></i> <span class="mandfield text-2 ml-1"><sup>*</sup></span>
-      
-      
+
+
                                                                      </label>
-      
+
                                                                      <input placeholder="eg. 1458,16325" [(ngModel)]="commodity.del" name="pu{{i}}{{y}}{{z}}"
-      
+
                                                                         type="text" class="form-control" >
                                                                         <!-- <div *ngIf="delNum.invalid && (delNum.dirty || delNum.touched)" class="text-danger">
                                                                            <div *ngIf="delNum.errors.pattern">
@@ -1181,27 +1181,27 @@
                                                                   <div class="col-lg-1 text-right mt-4 pl-0">
                                                                      <a class="btn btn-danger btn-sm mt-2" href="javascript:;" *ngIf="z != 0" (click)="removeCommodity('receiver', i, y, z)"><i class="fas fa-minus"></i> </a>
                                                                      <a class="btn btn-success btn-sm mt-2" href="javascript:;" *ngIf="z == 0" (click)="addCommodity('receiver', i, y)"><i class="fas fa-plus"></i></a>
-      
-      
+
+
                                                                   </div>
                                                                </div>
-      
+
                                                                <div class="row mt-3">
-                                                                  
+
                                                                   <div class="col-6">
                                                                         <label class="control-label font-weight-bold labelmt text-3 text-dark">Quantity
-                                                                           <span class="mandfield text-2 ml-1"><sup>*</sup></span>                                                                     
+                                                                           <span class="mandfield text-2 ml-1"><sup>*</sup></span>
                                                                         </label>
                                                                         <div class="row">
                                                                            <div class="col-lg-6">
-         
+
                                                                               <input placeholder="eg. 20,200" type="text" [(ngModel)]="commodity.quantity" name="quantity{{i}}{{y}}{{z}}" class="form-control" >
                                                                               <!-- <div *ngIf="txtQuantity.invalid && (txtQuantity.dirty || txtQuantity.touched)" class="text-danger">
                                                                                  <div *ngIf="txtQuantity.errors.pattern">
                                                                               Quantity must contains number only.
                                                                                  </div>
                                                                            </div> -->
-            
+
                                                                            <!-- <span class="text-danger"
                                                                               *ngIf="isReceiverSubmit &&  shippersReceivers[i].receivers.commodity[z].quantity == ''">
                                                                               This Field is required
@@ -1226,22 +1226,22 @@
                                                                               Select valid quantity from the list.
                                                                                  </div>
                                                                            </div> -->
-               
+
                                                                               <!-- <span class="text-danger"
                                                                                  *ngIf="isReceiverSubmit &&  shippersReceivers[i].receivers.commodity[z].quantityUnit == ''">
                                                                                  This Field is required
                                                                               </span> -->
-               
+
                                                                            </div>
                                                                         </div>
                                                                   </div>
                                                                   <div class="col-6">
                                                                      <label class="control-label font-weight-bold labelmt text-3 text-dark">Weight
-                                                                        <span class="mandfield text-2 ml-1"><sup>*</sup></span>                                                                     
+                                                                        <span class="mandfield text-2 ml-1"><sup>*</sup></span>
                                                                      </label>
                                                                      <div class="row">
                                                                         <div class="col-lg-6">
-                                                                           
+
                                                                            <input placeholder="eg. 500 Kg" type="text" [(ngModel)]="commodity.weight" name="weight{{i}}{{y}}{{z}}" class="form-control" >
                                                                            <!-- <div *ngIf="txtWeight.invalid && (txtWeight.dirty || txtWeight.touched)" class="text-danger">
                                                                               <div *ngIf="txtWeight.errors.pattern">
@@ -1253,7 +1253,7 @@
                                                                               This Field is required
                                                                            </span> -->
                                                                         </div>
-            
+
                                                                         <div class="col-lg-6">
                                                                            <ng-select placeholder="eg. select weight" dropdownPosition='top' [(ngModel)]="commodity.weightUnit" name="weightUnit{{i}}{{y}}{{z}}" class="form-control" data-select2-id="19" tabindex="-1" aria-hidden="false" >
                                                                                  <ng-option value="ton(s)">ton(s)</ng-option>
@@ -1265,7 +1265,7 @@
                                                                             Select valid weight from the list.
                                                                                </div>
                                                                           </div> -->
-            
+
                                                                            <!-- <span class="text-danger"
                                                                               *ngIf="isReceiverSubmit && shippersReceivers[i].receivers.commodity[z].weightUnit == ''">
                                                                               This Field is required
@@ -1273,22 +1273,22 @@
                                                                         </div>
                                                                      </div>
                                                                   </div>
-      
+
                                                                </div>
                                                                <div class="row mt-3">
-                                                                  
-      
+
+
                                                                </div>
                                                             </div>
                                                             <div class="row mt-3">
-      
+
                                                                <div class="col-lg-12 col-md-12">
                                                                   <label class="control-label font-weight-bold labelmt text-3 text-dark"
                                                                      for="inputDefault">Delivery Instruction</label>
-      
+
                                                                   <textarea placeholder="eg. Enter delivery instruction" [(ngModel)]="dropItem.dropOffInstruction"
                                                                      name="dropOffInstruction_{{i}}{{y}}" class="form-control h-auto" rows="2" #Deliv1= "ngModel" pattern ="^[\s\S]{500}$"
-      
+
                                                                      style="margin-top: 0px; margin-bottom: 0px; height: 74px;"></textarea>
                                                                      <!-- <div *ngIf="Deliv1.invalid && (Deliv1.dirty || Deliv1.touched)" class="text-danger">
                                                                       <div>
@@ -1298,11 +1298,11 @@
                                                                       </div>
                                                                     </div> -->
                                                                </div>
-      
+
                                                             </div>
                                                          </div>
                                                       </div>
-                                                     
+
                                                       <div class="row mt-3 mr-4">
                                                          <div class="col-3">
                                                             <label class="control-label font-weight-bold mb-0 mt-2 text-3 text-dark"
@@ -1387,7 +1387,7 @@
                                  <!-- <div class="row mt-3">
 
                                     <div class="col-lg-8 offset-lg-2">
-                                       
+
                                        <div class="checkbox-custom checkbox-default">
                                           <input (change)="checkTrailer($event.target.value)"
                                              [(ngModel)]="orderData.additionalDetails.dropTrailer" name="dropTrailer"
@@ -1437,7 +1437,7 @@
                                            </div>
                                       </div> -->
                                     </div>
-                                    
+
                                     <div class="col-4">
                                        <label class="control-label font-weight-bold text-3 text-dark"
                                           for="inputDefault">Seal#</label>
@@ -1447,12 +1447,12 @@
 
                                            <ng-option value="customer_seal">Customer Seal</ng-option>
                                            <ng-option value="company_seal">Company Seal</ng-option>
-                                       
+
                                        </ng-select>
                                        <div *ngIf="orderData.additionalDetails.sealType != ''">
                                           <input class="form-control" placeholder="Type seal number" name="sealNo" [(ngModel)]="orderData.additionalDetails.sealNo" type="text">
                                        </div>
-                                       
+
                                     </div>
                                  </div>
 
@@ -2084,8 +2084,8 @@
                            </div>
                            <div class="form-group row">
                               <div class="col-lg-11 text-right pr-0">
-                                 <a href="javascript:;" routerLink="/dispatch/orders"
-                                    class="mb-1 mt-1 mr-2 btn btn-default">Cancel</a>
+                                 <button type="button" (click)="cancel()"
+                                    class="mb-1 mt-1 mr-2 btn btn-default">Cancel</button>
                                  <button *ngIf="!getOrderID" type="button" (click)="onSubmit()" [disabled]="disableButton() || submitDisabled" class="btn btn-success" >Save</button>
                                  <button *ngIf="getOrderID" type="button" (click)="updateOrder()" [disabled]="disableButton() || submitDisabled || ifStatus == 'delivered' || isInvoiceGenerated" class="btn btn-success text-white" >Update</button>
                               </div>

--- a/src/app/pages/dispatch/orders/add-orders/add-orders.component.ts
+++ b/src/app/pages/dispatch/orders/add-orders/add-orders.component.ts
@@ -26,8 +26,8 @@ import { HttpClient } from '@angular/common/http';
 import * as moment from 'moment';
 import { DomSanitizer} from '@angular/platform-browser';
 import { CountryStateCity } from "src/app/shared/utilities/countryStateCities";
-import { element } from "protractor";
 import { Auth } from "aws-amplify";
+import { Location } from '@angular/common';
 
 declare var $: any;
 declare var H: any;
@@ -367,7 +367,8 @@ export class AddOrdersComponent implements OnInit {
     private pdfService: PdfAutomationService,
     private httpClient: HttpClient,
     private listService: ListService,
-    private domSanitizer: DomSanitizer
+    private domSanitizer: DomSanitizer,
+    private location: Location,
   ) {
     const current = new Date();
     // config.minDate = {
@@ -438,7 +439,9 @@ export class AddOrdersComponent implements OnInit {
       // .subscribe((v: any) => {
       // });
   }
-
+  cancel() {
+    this.location.back(); // <-- go back to previous location on cancel
+  }
   async getCarrierState() {
     let carrierID = (await Auth.currentSession()).getIdToken().payload.carrierID;
     let result: any = await this.apiService.getData(`carriers/${carrierID}`).toPromise();
@@ -1296,7 +1299,7 @@ export class AddOrdersComponent implements OnInit {
       next: (res) => {
         this.submitDisabled = false;
         this.toastr.success("Order added successfully");
-        this.router.navigateByUrl("/dispatch/orders");
+        this.cancel();
       },
     });
   }
@@ -1995,7 +1998,7 @@ export class AddOrdersComponent implements OnInit {
       next: (res) => {
         this.submitDisabled = false;
         this.toastr.success("Order updated successfully");
-       this.router.navigateByUrl("/dispatch/orders");
+        this.cancel();
       },
     });
   }

--- a/src/app/pages/dispatch/orders/orders-list/orders-list.component.ts
+++ b/src/app/pages/dispatch/orders/orders-list/orders-list.component.ts
@@ -175,7 +175,7 @@ export class OrdersListComponent implements OnInit {
       //   }
       // }
 
-      if(element.orderStatus == 'confirmed') {
+      if(element.orderStatus === 'confirmed') {
 
         this.confirmOrders.push(element);
       } else if(element.orderStatus == 'dispatched') {
@@ -425,8 +425,20 @@ export class OrdersListComponent implements OnInit {
   }
 
   async changeStatus(id) {
-    let result = await this.apiService.getData('orders/update/orderStatus/' + id + '/confirmed').toPromise();
-    console.log('result', result);
-    await this.fetchAllTypeOrderCount();
+    if (confirm('Are you sure you want to confirm the order?') === true) {
+      const result = await this.apiService.getData('orders/update/orderStatus/' + id + '/confirmed').toPromise();
+      console.log('result', result);
+      if (result) {
+        this.orders = [];
+        this.confirmOrders = [];
+        this.dispatchOrders = [];
+        this.deliveredOrders = [];
+        this.cancelledOrders = [];
+        this.invoicedOrders = [];
+        this.partiallyOrders = [];
+        this.fetchAllTypeOrderCount();
+      }
+    }
+
   }
 }

--- a/src/app/pages/dispatch/trips/add-trip/add-trip.component.html
+++ b/src/app/pages/dispatch/trips/add-trip/add-trip.component.html
@@ -705,7 +705,7 @@
                         </div>
                     </div>
 
-                    <div class="row mb-3">
+                    <!-- <div class="row mb-3">
                         <div class="col-lg-12">
                             <div class="bg-white p-3 text-dark">
                                 <div class="form-group row pt-3">
@@ -723,7 +723,7 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </div> -->
 
                     <div class="row mb-3">
                         <div class="col-lg-12">
@@ -788,32 +788,67 @@
 
                                 </div>
 
-                                <div class="form-group row text-right mt-3">
-                                    <div class="col-lg-12 pr-3">
-                                        <a class="mt-1 mr-2 btn btn-default" href="javascript:;"
-                                            routerLink="/dispatch/trips/trip-list">Cancel</a>
 
-                                        <!-- if there is some error in validation  -->
-                                        <!-- <button *ngIf="!tripID && !tripForm.form.valid" class="btn btn-success mt-1"
-                                  [disabled]="!tripForm.form.valid">Create Trip</button> -->
-
-                                        <!-- if validations are ok and now the button will disable on submit click  -->
-                                        <button (click)="createTrip()" *ngIf="!tripID" class="btn btn-success mt-1"
-                                            [disabled]="submitDisabled">Create Trip</button>
-
-                                        <!-- update case -->
-                                        <!-- <button *ngIf="tripID && !tripForm.form.valid" class="btn btn-success mt-1" [disabled]="!tripForm.form.valid">
-                                  Update Trip</button> -->
-
-                                        <button (click)="updateTrip()" *ngIf="tripID" class="btn btn-success mt-1"
-                                            [disabled]="submitDisabled">Update Trip</button>
-                                    </div>
-                                </div>
                             </div>
                         </div>
                     </div>
+                    <div class="row">
+                      <div class="col-12">
+                        <mat-accordion>
+                          <mat-expansion-panel hideToggle >
+                            <mat-expansion-panel-header>
+                              <mat-panel-title>
+                                <label
+                                class="control-label text-lg-right text-5">Map View</label>
+                              </mat-panel-title>
+                            </mat-expansion-panel-header>
+                            <div class="row mb-3">
+                              <div class="col-lg-12">
+                                  <div class="bg-white p-3 text-dark">
+                                      <div class="form-group row pt-2">
+                                          <div class="col-lg-12 mb-2">
+                                              <ng-template [ngIf]="selectedVehicleSpecs.length==0 && trips.length>1">
+                                                  <p class="text-4 font-weight-normal">*Vehicle is missing. To get specific
+                                                      Vehicle route please select the truck</p>
+                                              </ng-template>
+                                              <div class="mapclass" id="map_view">
+                                                  <div id="map" class=""></div>
+                                              </div>
+
+                                          </div>
+
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
 
 
+
+                          </mat-expansion-panel>
+                        </mat-accordion>
+
+                      </div>
+                    </div>
+                    <div class="form-group row text-right mt-3">
+                      <div class="col-lg-12 pr-3">
+                          <button type="button" class="mt-1 mr-2 btn btn-default" (click)="cancel()">Cancel</button>
+
+                          <!-- if there is some error in validation  -->
+                          <!-- <button *ngIf="!tripID && !tripForm.form.valid" class="btn btn-success mt-1"
+                    [disabled]="!tripForm.form.valid">Create Trip</button> -->
+
+                          <!-- if validations are ok and now the button will disable on submit click  -->
+                          <button (click)="createTrip()" *ngIf="!tripID" class="btn btn-success mt-1"
+                              [disabled]="submitDisabled">Create Trip</button>
+
+                          <!-- update case -->
+                          <!-- <button *ngIf="tripID && !tripForm.form.valid" class="btn btn-success mt-1" [disabled]="!tripForm.form.valid">
+                    Update Trip</button> -->
+
+                          <button (click)="updateTrip()" *ngIf="tripID" class="btn btn-success mt-1"
+                              [disabled]="submitDisabled">Update Trip</button>
+                      </div>
+                  </div>
                 </section>
             </form>
 

--- a/src/app/pages/dispatch/trips/trip-detail/trip-detail.component.html
+++ b/src/app/pages/dispatch/trips/trip-detail/trip-detail.component.html
@@ -10,6 +10,8 @@
                     </div>
 
                     <div class="col-md-8 col-lg-8 text-right pr-1">
+                      <a routerLink="/dispatch/trips/edit-trip/{{ tripID }}" class="btn btn-default btn-sm mr-2"><i
+                        class="fas fa-pencil-alt"></i> Edit Trip</a>
                         <!-- <a href="javascript:;" data-toggle="modal" data-target="#splitpopup" class="mb-1 modal-with-form  btn btn-sm btn-success">Split Trip</a> -->
                         <!-- <div class="btn-group flex-wrap mr-2">
                             <button type="button" class="btn btn-success btn-sm dropdown-toggle" data-toggle="dropdown"
@@ -171,7 +173,7 @@
                       </div>
                    </div>
                 </div>
-                
+
                 <div class="row mb-3">
                    <div class="col-lg-12">
                       <div class="bg-white p-3 text-dark">
@@ -262,7 +264,7 @@
                                         <div class="tripbarn"></div>
                                     </div>
                                 </div>
-        
+
                                 <div class="tripinfoscroll">
                                     <div class="row d-flex flex-row flex-nowrap justify-content-between pl-3 pr-3">
                                         <div class="text-center" *ngFor="let trip of trips">
@@ -304,13 +306,24 @@
                                 <div class="widgetload">
                                     <div class="widgettbload">
                                         <h2 class="pull-left mt-0 mb-0 text-4 font-weight-semibold text-dark"><i
-                                                class="fas fa-user"></i> Driver Activity</h2>
+                                                class="fas fa-user"></i> Trip Log</h2>
                                     </div>
                                 </div>
                                 <div class="timeline timeline-simple changelog"
                                     style="max-height: 497px;overflow-x: auto;width: 100%;">
                                     <div class="tm-body text-dark">
-                                        <ol class="tm-items">
+                                       <ol class="tm-items">
+                                            <li *ngFor="let trip of tripLog">
+                                                <div class="tm-box">
+                                                    <span class="release-date">{{trip.createdDate}} - {{trip.createdTime}}</span>
+                                                    <ul class="list-unstyled">
+                                                        <li> {{trip.eventParams.message}}
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </li>
+                                        </ol>
+                                        <!-- <ol class="tm-items">
                                             <li>
                                                 <div class="tm-box">
                                                     <span class="release-date">16 May 2020 04:10 PM</span>
@@ -387,12 +400,12 @@
                                                     </ul>
                                                 </div>
                                             </li>
-                                        </ol>
+                                        </ol> -->
                                     </div>
                                 </div>
                             </div>
                             </div>
-                            
+
                             <div class="col-6">
                                 <div class="vehicle-common-box w100 pull-left mb-3">
                                     <div class="widgetload">
@@ -404,10 +417,10 @@
                                                         <i class="fas fa-dollar-sign"></i> Expenses</h2>
                                                 </div>
                                                 <div class="col-lg-4 text-right mt-2">
-                                                    <a href="javascript:;" class=" btn btn-xs btn-dark"> Fuel
+                                                    <!-- <a href="javascript:;" class=" btn btn-xs btn-dark"> Fuel
                                                         Expenses</a>
                                                     <a href="javascript:;" class="btn btn-xs btn-dark ml-3"> Other
-                                                        Expenses</a>
+                                                        Expenses</a> -->
                                                 </div>
                                             </div>
                                         </div>
@@ -424,28 +437,22 @@
                                             </thead>
                                             <tbody>
                                                 <tr>
-                                                    <td> 05/25/2020</td>
-                                                    <td> Meal Expense</td>
-                                                    <td> Other Expense</td>
-                                                    <td> CAD 25.00</td>
+                                                    <td>&nbsp; </td>
+                                                    <td> &nbsp;</td>
+                                                    <td> &nbsp;</td>
+                                                    <td> &nbsp;</td>
                                                 </tr>
                                                 <tr>
-                                                    <td> 05/25/2020</td>
-                                                    <td> Parking</td>
-                                                    <td> Other Expense</td>
-                                                    <td> CAD 50.00</td>
+                                                    <td> &nbsp;</td>
+                                                    <td>&nbsp; </td>
+                                                    <td>&nbsp; </td>
+                                                    <td> &nbsp;</td>
                                                 </tr>
                                                 <tr>
-                                                    <td> 05/25/2020</td>
-                                                    <td> Meal Expense</td>
-                                                    <td> Other Expense</td>
-                                                    <td> CAD 25.00</td>
-                                                </tr>
-                                                <tr>
-                                                    <td> 05/25/2020</td>
-                                                    <td> Parking</td>
-                                                    <td> Other Expense</td>
-                                                    <td> CAD 50.00</td>
+                                                    <td>&nbsp; </td>
+                                                    <td> &nbsp;</td>
+                                                    <td> &nbsp;</td>
+                                                    <td> &nbsp;</td>
                                                 </tr>
                                             </tbody>
                                             <tfoot>
@@ -453,7 +460,7 @@
                                                     <td></td>
                                                     <td></td>
                                                     <td class="font-weight-bold">Total Amount</td>
-                                                    <td class="font-weight-bold">CAD 234</td>
+                                                    <td class="font-weight-bold">0</td>
                                                 </tr>
                                             </tfoot>
                                         </table>
@@ -496,7 +503,7 @@
                                                             </span>
                                                         </span>
                                                         <span *ngIf="!tripData.notifications">No</span>
-                                                        
+
                                                     </td>
                                                 </tr>
                                                 <tr>
@@ -525,7 +532,7 @@
                                                 <tr>
                                                     <td>
                                                         <span class="line-height-xl">
-                                                            <i class="fa fa-map-marker-alt"></i> Pick-up 
+                                                            <i class="fa fa-map-marker-alt"></i> Pick-up
                                                             {{ tripData.dateCreated | date:'yyyy/MM/dd' }} <span *ngIf="trips.length > 0">{{ trips[0].pickupTime }} </span>
                                                         </span>
                                                     </td>
@@ -549,8 +556,8 @@
                                                 <tr>
                                                     <td>
                                                         <span class="line-height-xl">
-                                                            <i class="fa fa-map-marker-alt"></i> Delivery  
-                                                            {{ tripData.dateCreated | date:'yyyy/MM/dd' }} <span *ngIf="trips.length > 0">{{ lastDelivery }} </span>    
+                                                            <i class="fa fa-map-marker-alt"></i> Delivery
+                                                            {{ tripData.dateCreated | date:'yyyy/MM/dd' }} <span *ngIf="trips.length > 0">{{ lastDelivery }} </span>
                                                         </span>
                                                     </td>
 
@@ -602,11 +609,11 @@
                        </div>
                     </div>
                  </div>
-                
+
              </section>
 
 
-       
+
         </section>
     </div>
 </section>

--- a/src/app/pages/dispatch/trips/trip-detail/trip-detail.component.ts
+++ b/src/app/pages/dispatch/trips/trip-detail/trip-detail.component.ts
@@ -35,7 +35,7 @@ export class TripDetailComponent implements OnInit {
       dropOff: false,
       tripToDriver: false,
       tripToDispatcher: false
-    }, 
+    },
     bol: '',
     dateCreated: ''
   };
@@ -75,7 +75,7 @@ export class TripDetailComponent implements OnInit {
   driversObject: any = {};
   lastDelivery = '';
   stops = 0;
-
+  tripLog = [];
   ngOnInit() {
     this.fetchAllVehiclesIDs();
     this.fetchAllAssetIDs();
@@ -85,11 +85,22 @@ export class TripDetailComponent implements OnInit {
     this.tripID = this.route.snapshot.params['tripID'];
     this.fetchTripDetail();
     this.mapShow();
-
+    this.fetchTripLog();
     // this.initSpeedChart();
     // this.initTemperatureChart();
   }
+fetchTripLog() {
+  const lastEvaluatedKey = '';
+  this.apiService.getData('auditLogs/fetch?lastEvaluatedKey=' + lastEvaluatedKey).subscribe((res: any) => {
+    // console.log('trip', res.Items);
 
+for (const element of res.Items) {
+  if (element.eventParams.eventID === this.tripID) {
+    this.tripLog.push(element);
+  }
+}
+  });
+}
   mapShow() {
     this.hereMap.mapSetAPI();
     this.hereMap.mapInit();
@@ -108,7 +119,7 @@ export class TripDetailComponent implements OnInit {
     this.apiService.getData('trips/' + this.tripID).
       subscribe((result: any) => {
         result = result.Items[0];
-        
+
         if(result.documents == undefined) {
           result.documents = [];
         }
@@ -120,7 +131,7 @@ export class TripDetailComponent implements OnInit {
 
         if(result.routeID != '' && result.routeID != undefined) {
           this.apiService.getData('routes/' + result.routeID).
-            subscribe((result: any) => { 
+            subscribe((result: any) => {
               this.routeName = result.Items[0].routeName;
             })
         }
@@ -152,7 +163,7 @@ export class TripDetailComponent implements OnInit {
 
         for (let i = 0; i < tripPlanning.length; i++) {
           const element = tripPlanning[i];
-          
+
           let obj = {
             assetID: element.assetID,
             carrierID: element.carrierID,
@@ -165,7 +176,7 @@ export class TripDetailComponent implements OnInit {
             coDriverID: element.coDriverID,
             driverUsername: element.driverUsername,
             locationName: element.location,
-            mileType: element.mileType, 
+            mileType: element.mileType,
             miles: element.miles,
             name: element.name,
             trailer: '',
@@ -188,9 +199,9 @@ export class TripDetailComponent implements OnInit {
             this.stops += 1;
           }
 
-          this.plannedMiles += parseFloat(element.miles); 
+          this.plannedMiles += parseFloat(element.miles);
           this.newCoords.push(`${element.lat},${element.lng}`);
-          this.trips.push(obj);     
+          this.trips.push(obj);
         }
 
         if(this.newCoords.length > 0) {
@@ -385,7 +396,7 @@ export class TripDetailComponent implements OnInit {
         let file = this.uploadedDocs[j];
         formData.append(`uploadedDocs-${j}`, file);
       }
-      
+
       formData.append('data', JSON.stringify(this.tripData.documents));
 
       this.apiService.postData('trips/update/bol/'+this.tripID,formData, true).subscribe({
@@ -408,8 +419,8 @@ export class TripDetailComponent implements OnInit {
             });
         },
         next: (res:any) => {
-          this.tripData.documents = res; 
-          
+          this.tripData.documents = res;
+
           this.uploadedDocSrc = [];
           if (res.length > 0) {
             for (let k = 0; k < res.length; k++) {

--- a/src/app/pages/dispatch/trips/trip-list/trip-list.component.html
+++ b/src/app/pages/dispatch/trips/trip-list/trip-list.component.html
@@ -11,7 +11,7 @@
                             <ng-select [(ngModel)]="tripsFiltr.category" name="category" placeholder="Search by Category" (change)="categoryChange($event)" >
                                 <ng-option *ngFor="let data of categoryFilter" value="{{ data.value }}"> {{ data.name }}</ng-option>
                             </ng-select>
-                        </div> 
+                        </div>
                         <div class="col-md-2 col-lg-2 pr-1">
                             <div class="input-group input-group-md mb-3" *ngIf="tripsFiltr.category != 'driver' && tripsFiltr.category != 'vehicle' && tripsFiltr.category != 'asset' && tripsFiltr.category != 'tripType' && tripsFiltr.category != 'orderNo'  && tripsFiltr.category != 'tripStatus'">
                                 <input type="text" class="form-control" placeholder="Search" name="searchValue" [(ngModel)]="tripsFiltr.searchValue">
@@ -42,7 +42,7 @@
                                 <ng-option *ngFor="let data of ordersObject | keyvalue" value="{{ data.key }}"> {{ data.value }}</ng-option>
                             </ng-select>
                         </div>
-                        
+
                         <div class="col-lg-3 col-md-3 pr-1">
                             <div class="input-daterange input-group">
                                 <span class="input-group-prepend">
@@ -181,7 +181,7 @@
                                                         {{ carriersObject[trip.planCarrierId] }}
                                                         <span *ngIf="trip.carrierIdCount > 1" class="badge badge-dark ng-star-inserted"> +{{ trip.carrierIdCount-1 }} </span>
                                                     </td>
-                                                    <td><span class="badge badge-dark p-1">{{ trip.tripStatus }}</span></td>
+                                                    <td><span class="badge badge-dark p-1">{{ trip.tripStatus | titlecase}}</span></td>
                                                     <td>
                                                         <div class="dropdown dropright">
                                                             <button class="bg-transparent border-0" type="button"
@@ -213,7 +213,7 @@
                                             <button type="button" class="btn btn-default" (click)="nextResults('all')" [disabled]="tripNext">Next</button>
                                         </div>
                                     </div>
-            
+
                                     <div class="tab-pane table-responsive" [ngClass]="{'show active': activeTab == 'confirmed'}" id="confirmed" role="tabpanel" aria-labelledby="confirmed-tab" *ngIf="activeTab == 'confirmed'">
                                         <table class="row-border hover table table-bordered table-striped mb-0" id="confirmedTripsDT">
                                             <thead>
@@ -294,7 +294,7 @@
                                             </tbody>
                                         </table>
                                     </div>
-            
+
                                     <div class="tab-pane table-responsive" [ngClass]="{'show active': activeTab == 'dispatched'}" id="dispatched" role="tabpanel" aria-labelledby="dispatched-tab" *ngIf="activeTab == 'dispatched'">
                                         <table class="row-border hover table table-bordered table-striped mb-0" id="dispatchedTripsDT">
                                             <thead>
@@ -375,7 +375,7 @@
                                             </tbody>
                                         </table>
                                     </div>
-            
+
                                     <div class="tab-pane table-responsive" [ngClass]="{'show active': activeTab == 'started'}" id="started" role="tabpanel" aria-labelledby="started-tab" *ngIf="activeTab == 'started'">
                                         <table class="row-border hover table table-bordered table-striped mb-0" id="startedTripsDT">
                                             <thead>
@@ -456,7 +456,7 @@
                                             </tbody>
                                         </table>
                                     </div>
-            
+
                                     <div class="tab-pane table-responsive" [ngClass]="{'show active': activeTab == 'enroute'}" id="enroute" role="tabpanel" aria-labelledby="enroute-tab" *ngIf="activeTab == 'enroute'">
                                         <table class="row-border hover table table-bordered table-striped mb-0" id="enrouteTripsDT">
                                             <thead>
@@ -537,7 +537,7 @@
                                             </tbody>
                                         </table>
                                     </div>
-            
+
                                     <div class="tab-pane table-responsive" [ngClass]="{'show active': activeTab == 'cancelled'}" id="cancelled" role="tabpanel" aria-labelledby="cancelled-tab" *ngIf="activeTab == 'cancelled'">
                                         <table class="row-border hover table table-bordered table-striped mb-0" id="cancelledTripsDT">
                                             <thead>
@@ -617,7 +617,7 @@
                                             </tbody>
                                         </table>
                                     </div>
-            
+
                                     <div class="tab-pane table-responsive" [ngClass]="{'show active': activeTab == 'delivered'}" id="delivered" role="tabpanel" aria-labelledby="delivered-tab" *ngIf="activeTab == 'delivered'">
                                         <table class="row-border hover table table-bordered table-striped mb-0" id="deliveredTripsDT">
                                             <thead>
@@ -700,15 +700,15 @@
                                     </div>
                                 </div>
                             </div>
-                            
+
                          </div>
                       </div>
                    </div>
                 </div>
              </section>
 
-           
-             
+
+
         </section>
     </div>
 </section>

--- a/src/app/pages/dispatch/trips/trip.module.ts
+++ b/src/app/pages/dispatch/trips/trip.module.ts
@@ -16,6 +16,7 @@ import { unsavedChangesGuard } from 'src/app/guards/unsaved-changes.guard';
 import { AddTripComponent } from './add-trip/add-trip.component';
 import { TripListComponent } from './trip-list/trip-list.component';
 import { TripDetailComponent } from './trip-detail/trip-detail.component';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 /**
  * This Service handles how the date is represented in scripts i.e. ngModel.
@@ -104,7 +105,8 @@ const routes: Routes = [
     NgSelectModule,
     NgxSpinnerModule,
     ChartsModule,
-    DragDropModule
+    DragDropModule,
+    MatExpansionModule
   ],
   providers: [unsavedChangesGuard,
     { provide: NgbDateAdapter, useClass: CustomAdapter },

--- a/src/app/pages/fleet/assets/add-assets/add-assets.component.html
+++ b/src/app/pages/fleet/assets/add-assets/add-assets.component.html
@@ -16,7 +16,7 @@
 
       <section class="m-2">
         <form class="form-horizontal form-bordered" method="get" name="form" id="form_" #assetF="ngForm">
-        
+
         <div class="row mb-3">
          <div class="col-lg-12">
           <div class="bg-white p-3 text-dark">
@@ -33,7 +33,7 @@
                  <div class="row">
                   <div class="col-lg-10">
                     <label class="control-label font-weight-bold font-bold text-lg-right pt-2">Asset Name/Number <span class="mandfield text-2 ml-1"><sup>*</sup></span></label>
-                    <input type="text" [(ngModel)]="assetsData.assetIdentification" name="assetIdentification" maxlength="20" 
+                    <input type="text" [(ngModel)]="assetsData.assetIdentification" name="assetIdentification" maxlength="20"
                       class="form-control" placeholder="eg. Box asset" #aName="ngModel" required pattern="^[a-zA-Z0-9\s]+$">
                       <div *ngIf="aName.invalid && (aName.dirty || aName.touched)" class="text-danger">
                         <div *ngIf="aName.errors.required">
@@ -204,11 +204,11 @@
 
                     </ng-select>
                     <div *ngIf="sSlt.invalid && (sSlt.dirty || sSlt.touched)" class="text-danger">
-                      
+
                         <div *ngIf="sSlt.errors.required">
                           Status is required.
                         </div>
-                      
+
 
                     </div>
                   </div>
@@ -248,11 +248,11 @@
                       <input [(ngModel)]="assetsData.assetDetails.height" name="assetDetails.height" min="0" type="number"
                         class="form-control" placeholder="eg.170.4 inch or 14.2 feet" #heightTxt="ngModel">
                         <!-- <div *ngIf="heightTxt.invalid && (heightTxt.dirty || heightTxt.touched)" class="text-danger">
-                          
+
                             <div *ngIf="heightTxt.errors.required">
                             Height must contain numbers.
                             </div>
-                          
+
 
                         </div> -->
                       </div>
@@ -412,7 +412,7 @@
                       </div>
                     </div>
                   </div>
-                </div> 
+                </div>
                </div>
                <div class="col-lg-5 offset-lg-1 mb-3">
                 <div class="row">
@@ -548,7 +548,7 @@
                         class="fas fa-plus"></i></a>
                     <a (click)="getInspectionForms();"target="_blank" aria-hidden="true" class="ml-1 mmodal-with-form cus-btn-padd btn btn-success"><i style="color:#fff;"
                           class="fas fa-sync-alt"></i></a>
-                  </div> 
+                  </div>
                 </div>
 
                 <div class="row mt-2">
@@ -831,21 +831,21 @@
             <div class="form-group adddriverpl row">
               <div class="col-lg-11 text-right pb-3">
                 <div class="row">
-                  
+
                   <div class="col-12">
                     <div class="row">
                       <div class="col-11 pr-0">
-                        <a routerLink="/fleet/assets/list" class="btn cus-btn-padd btn-default mr-2">Cancel</a>
+                        <button type="button" (click)="cancel()" class="btn cus-btn-padd btn-default mr-2">Cancel</button>
                         <!-- if there is some error in validation  -->
 
                         <button [disabled]="!assetF.form.valid" *ngIf="!assetID && !assetF.form.valid"
                         (click)="addAsset()" class="btn cus-btn-padd btn-success" id="nextBtn">Save</button>
-                      
+
                         <!-- if validations are ok and now the button will disable on submit click  -->
 
                       <button [disabled]="submitDisabled" *ngIf="!assetID && assetF.form.valid" (click)="addAsset()"
                         class="btn cus-btn-padd btn-success" id="nextBtn">Save</button>
-                      
+
                         <!-- update case -->
                       <button [disabled]="!assetF.form.valid" *ngIf="assetID && !assetF.form.valid"
                         (click)="updateAsset()" class="btn cus-btn-padd btn-success">Update</button>
@@ -866,7 +866,7 @@
       </form>
      </section>
 
-     
+
 
     </section>
   </div>

--- a/src/app/pages/fleet/assets/add-assets/add-assets.component.ts
+++ b/src/app/pages/fleet/assets/add-assets/add-assets.component.ts
@@ -7,6 +7,7 @@ import { ToastrService } from 'ngx-toastr';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { NgbCalendar, NgbDateAdapter} from '@ng-bootstrap/ng-bootstrap';
 declare var $: any;
+import { Location } from '@angular/common';
 import { DomSanitizer} from '@angular/platform-browser';
 import { ListService } from '../../../../services/list.service';
 import * as moment from 'moment';
@@ -117,6 +118,7 @@ export class AddAssetsComponent implements OnInit {
 
   constructor(private apiService: ApiService, private route: ActivatedRoute,
               private router: Router, private ngbCalendar: NgbCalendar, private dateAdapter: NgbDateAdapter<string>,
+              private location: Location,
               private toastr: ToastrService, private listService: ListService, private spinner: NgxSpinnerService, private domSanitizer: DomSanitizer) {
       this.selectedFileNames = new Map<any, any>();
   }
@@ -159,7 +161,9 @@ export class AddAssetsComponent implements OnInit {
     }
   }
 
-
+  cancel() {
+    this.location.back(); // <-- go back to previous location on cancel
+  }
   resetModel(){
     this.assetsData.assetDetails.model = '';
     $('#assetSelect').val('');
@@ -270,7 +274,7 @@ export class AddAssetsComponent implements OnInit {
         this.submitDisabled = false;
         this.response = res;
         this.toastr.success('Asset added successfully.');
-        this.router.navigateByUrl('/fleet/assets/list');
+        this.cancel();
       },
     });
   }
@@ -466,7 +470,7 @@ export class AddAssetsComponent implements OnInit {
         this.response = res;
         this.hasSuccess = true;
         this.toastr.success('Asset updated successfully.');
-        this.router.navigateByUrl('/fleet/assets/list');
+        this.cancel();
         this.Success = '';
       },
     });

--- a/src/app/pages/fleet/assets/asset-detail/asset-detail.component.html
+++ b/src/app/pages/fleet/assets/asset-detail/asset-detail.component.html
@@ -9,6 +9,8 @@
                <h4 class="font-weight-bold text-4 mt-0 text-dark">Asset Details</h4>
             </div>
             <div class="col-md-8 col-lg-8 text-right pr-1">
+              <a routerLink="/fleet/assets/edit/{{assetID}}" class="btn btn-default btn-sm mr-2"><i
+                class="fas fa-pencil-alt"></i> Edit Asset</a>
              <a routerLink="/fleet/assets/list" class="btn btn-sm btn-default"><i class="fas fa-list"></i> Assets List</a>
           </div>
          </div>
@@ -97,7 +99,7 @@
                                             <td class="back-color-gray font-weight-bold">Owner Operator Name</td>
                                             <td class="text-capitalize">{{contactsObjects[ownerOperatorName]}}</td>
                                          </tr>
-                                         <tr *ngIf="inspectionFormName != ''"> 
+                                         <tr *ngIf="inspectionFormName != ''">
                                             <td class="back-color-gray font-weight-bold">Inspection Form Name</td>
                                                <td class="text-capitalize">
                                                    <a href="#inspectionFormModal" data-toggle="modal" data-target="#inspectionFormModal" class="modal-with-form font-weight-bold">{{inspectionFormName ? inspectionFormName : '-'}}

--- a/src/app/pages/fleet/drivers/add-driver/add-driver.component.ts
+++ b/src/app/pages/fleet/drivers/add-driver/add-driver.component.ts
@@ -402,7 +402,7 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
     });
   }
   fetchTimezones() {
-    
+
     const UStimezones = ct.getTimezonesForCountry('US');
     UStimezones.forEach((element: any) => {
       const obj: any = {
@@ -671,9 +671,9 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
   }
 
   async newGeoCode(data: any) {
-   
+
     let result = await this.apiService.getData(`pcMiles/geocoding/${encodeURIComponent(JSON.stringify(data))}`).toPromise();
-    
+
     if(result.items != undefined && result.items.length > 0) {
       return result.items[0].position;
     }
@@ -737,21 +737,21 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
            countryName: element.countryName,
            zipCode: element.zipCode
          }
-        
+
          $('#addErr'+i).css('display','none');
          let result = await this.newGeoCode(data);
-         
+
          if(result == null) {
             $('#addErr'+i).css('display','block');
             return false;
-          } 
+          }
          if(result != undefined){
            element.geoCords = result;
          }
-         
+
        }
     }
-   
+
     // create form data instance
     const formData = new FormData();
     // append photos if any
@@ -828,7 +828,7 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
   }
 
   async userAddress(i, item) {
-    
+
     this.driverData.address[i].userLocation = item.address.label;
     this.driverData.address[i].zipCode = item.address.Zip;
 
@@ -839,9 +839,9 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
 
     this.driverData.address[i].stateName = item.address.StateName;
     this.driverData.address[i].cityName = item.address.City;
-    
+
     this.driverData.address[i].address1 = item.address.StreetAddress ? item.address.StreetAddress : '';
-  
+
   }
 
   remove(obj, i, addressID = null) {
@@ -856,7 +856,7 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
   throwErrors() {
     from(Object.keys(this.errors))
       .subscribe((v) => {
-       
+
         if(v==='userName' || v==='email' || v==='employeeContractorId' || v==='CDL_Number' || v==='SIN'){
           $('[name="' + v + '"]')
           .after('<label id="' + v + '-error" class="error" for="' + v + '">' + this.errors[v] + '</label>')
@@ -926,7 +926,7 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
         this.driverData.corporationType = result.corporationType;
         this.driverData.vendor = result.vendor;
         this.driverData.corporation = result.corporation;
-        
+
         this.driverData.ownerOperator = result.ownerOperator;
         this.driverData.driverStatus = result.driverStatus;
         this.driverData.userName = result.userName;
@@ -1076,9 +1076,9 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
            countryName: element.countryName,
            zipCode: element.zipCode
          }
- 
+
          let result = await this.newGeoCode(data);
-         
+
          if(result != undefined){
            element.geoCords = result;
          }
@@ -1152,8 +1152,7 @@ export class AddDriverComponent implements OnInit, OnDestroy, CanComponentDeacti
             this.isSubmitted = true;
             this.submitDisabled = false;
             this.toastr.success('Driver updated successfully');
-            this.router.navigateByUrl('/fleet/drivers/list');
-          //  this.cancel();
+            this.cancel();
 
           },
         });

--- a/src/app/pages/fleet/drivers/driver-detail/driver-detail.component.html
+++ b/src/app/pages/fleet/drivers/driver-detail/driver-detail.component.html
@@ -8,8 +8,10 @@
           </div>
 
           <div class="col-md-10 col-lg-10 text-right pr-1">
-            <a class="text-uppercase btn btn-sm btn-dark mr-3" data-toggle="modal"
+            <a class="text-uppercase btn btn-sm btn-dark mr-2" data-toggle="modal"
               data-target="#driverOtherDetailsModal" href="javascript:;">Driver Detailed Information</a>
+              <a routerLink="/fleet/drivers/edit/{{driverID}}" class="btn btn-default btn-sm mr-2"><i
+                class="fas fa-pencil-alt"></i> Edit Driver</a>
             <a routerLink="/fleet/drivers/list" class="btn btn-sm btn-default"><i class="fas fa-list"></i> Drivers
               List</a>
           </div>
@@ -72,7 +74,7 @@
               </div>
             </div>
           </div>
-          <div class="col-lg-6 pr-1 pl-2 mt-3">
+          <!-- <div class="col-lg-6 pr-1 pl-2 mt-3">
             <div class="bg-white ssdriver p-2">
               <h2 class="font-weight-bold text-dark text-5 mt-0 mb-2">Safety Summary</h2>
               <div class="row text-center">
@@ -146,8 +148,8 @@
                 </div>
               </div>
             </div>
-          </div>
-          <div class="col-lg-6 pr-1 pl-2 mt-3">
+          </div> -->
+          <div class="col-lg-12 pr-1 pl-2 mt-3">
             <div class="bg-white p-2">
               <h2 class="font-weight-normal text-dark text-5 mt-0 mb-1">Trips</h2>
               <table id="diverTbl" class="row-border hover table table-bordered table-striped mb-0">

--- a/src/app/pages/fleet/drivers/driver-detail/driver-detail.component.ts
+++ b/src/app/pages/fleet/drivers/driver-detail/driver-detail.component.ts
@@ -24,7 +24,7 @@ export class DriverDetailComponent implements OnInit {
   email: string;
   homeTerminal: string;
   cycle: string;
-  private driverID: string;
+  public driverID: string;
   private driverData: any;
   private driverDataUpdate: any;
   carrierID: any;
@@ -125,7 +125,7 @@ export class DriverDetailComponent implements OnInit {
   corporationType: any;
   vendor: any;
   corporation: any;
-  
+
   constructor(
     private hereMap: HereMapService,
     private apiService: ApiService,

--- a/src/app/pages/fleet/vehicles/add-vehicle-new/add-vehicle-new.component.ts
+++ b/src/app/pages/fleet/vehicles/add-vehicle-new/add-vehicle-new.component.ts
@@ -331,11 +331,11 @@ export class AddVehicleNewComponent implements OnInit {
   fetchManufacturers() {
     this.httpClient.get('assets/jsonFiles/vehicles/trucks.json').subscribe((data: any) => {
       data.forEach(element => {
-        
+
         this.manufacturerDataSource.push(Object.keys(element)[0].toUpperCase())
-        
+
       });
-    
+
     });
   }
   fetchModels(){
@@ -347,12 +347,12 @@ export class AddVehicleNewComponent implements OnInit {
         if(element[manufacturer]){
           element[manufacturer].forEach(element => {
             output.push(element.toUpperCase());
-            
+
           });
         this.modals=output
         }
       });
-    
+
     });
 
   }
@@ -566,7 +566,7 @@ export class AddVehicleNewComponent implements OnInit {
     };
 
     // create form data instance
-    // console.log(data); 
+    // console.log(data);
     // return;
     const formData = new FormData();
 
@@ -1092,7 +1092,7 @@ export class AddVehicleNewComponent implements OnInit {
             this.response = res;
             this.Success = '';
             this.toastr.success('Vehicle Updated successfully');
-            this.router.navigateByUrl('/fleet/vehicles/list');
+            this.cancel();
           }
         })
       });
@@ -1230,7 +1230,7 @@ export class AddVehicleNewComponent implements OnInit {
         }
         this.documentSlides.push(obj);
       })
-    }); 
+    });
   }
 
   clearGroup() {

--- a/src/app/pages/fleet/vehicles/vehicle-detail/vehicle-detail.component.html
+++ b/src/app/pages/fleet/vehicles/vehicle-detail/vehicle-detail.component.html
@@ -7,18 +7,11 @@
             <h4 class="text-4 mt-0 mb-0 text-dark">Vehicle Details</h4>
           </div>
           <div class="col-md-8 col-lg-8 text-right">
+            <a routerLink="/fleet/vehicles/edit/{{vehicleID}}" class="btn btn-default btn-sm mr-2"><i
+              class="fas fa-pencil-alt"></i> Edit Vehicle</a>
             <a routerLink="/fleet/vehicles/list" class="btn btn-default btn-sm"><i class="fas fa-list"></i> Vehicles
               List</a>
-            <div class="btn-group flex-wrap" *ngIf="!environment.isFeatureEnabled">
-              <button type="button" class="btn btn-success btn-sm dropdown-toggle" data-toggle="dropdown"
-                aria-expanded="false">Actions<span class="caret"></span></button>
-              <div class="dropdown-menu" role="menu" x-placement="bottom-start"
-                style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(0px, 38px, 0px);">
-                <a class="dropdown-item text-1" routerLink="/fleet/vehicles/edit/{{vehicleID }}"
-                  href="javascript:;">Edit</a>
-                <a class="modal-with-form dropdown-item text-1" (click)="deleteVehicle()" href="javascript:;">Delete</a>
-              </div>
-            </div>
+
           </div>
         </div>
       </header>
@@ -830,7 +823,7 @@
                   Default Inspection Form:
                 </div>
                 <div class="col-lg-9">
-                  <span *ngIf="inspectionForms"> 
+                  <span *ngIf="inspectionForms">
                     <span *ngIf="inspectionForms.isDefaultInspectionType=='0'">NO</span>
                     <span *ngIf="inspectionForms.isDefaultInspectionType=='1'">YES</span>
                   </span>


### PR DESCRIPTION
Update Status on Order's not updating the status right away. ( provide a status message)
Here maps Src - Destination details not showing up in Here maps in Trips
Orders/Trips - Whenver user updates the details, it should stay on the same page in non-editable mode.
Drivers/Vehiciles/Assets should have direct edit page on the detail page.
Remove status data on Driver activity and Expenes
Make Maps collapsable and move it at the end of the page.
Remove import/export fucntionality on Driver payments and other spots.
Chat of Accounts not showing all the entries on the page
Driver payment details not showing up in the detail page, it is opening Carrier Payment page
Show Seperate Iyem for CPP and EI and For total Taxes add - Federal and provincial - Driver
Reduce decimal places in settlement to 2 places.
Check all the cancel button in accounting 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist: (Check only applicable)

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
